### PR TITLE
5.2: Rewrite "info variables -p"

### DIFF
--- a/lib/msg.sh
+++ b/lib/msg.sh
@@ -131,6 +131,21 @@ function _Dbg_printf_nocr {
     fi
 }
 
+# Like _Dbg_msg but does not evaluate escape sequences which are embedded in the arguments
+# print message to output device
+function _Dbg_msg_verbatim {
+    if (( _Dbg_logging )) ; then
+        builtin echo -E "$@" >>$_Dbg_logging_file
+    fi
+    if (( ! _Dbg_logging_redirect )) ; then
+        if [[ -n $_Dbg_tty  ]] && [[ $_Dbg_tty != '&1' ]] ; then
+            builtin echo -E "$@" >>$_Dbg_tty
+        else
+            builtin echo -E "$@"
+        fi
+    fi
+}
+
 typeset _Dbg_dashes='---------------------------------------------------'
 
 # print message to output device


### PR DESCRIPTION
Rewrite `info variables` to support line feeds and spaces in values, array keys and array values.

Bash's `typeset -p` escapes line feeds and other special characters and wraps such values in `$''`. Array keys with spaces are wrapped into `""`. Previously, `$''` was kept but the escape codes were resolved. The escape codes are now retained in the output of `info variables` to show each variable and its value on a single line. This is to improve readability and help programmatic parsing of the variable listing.