### PR TITLE
5.2: Fix step command

### DIFF
--- a/command/next.sh
+++ b/command/next.sh
@@ -1,7 +1,8 @@
 # -*- shell-script -*-
 # gdb-like "next" (step through) commmand.
 #
-#   Copyright (C) 2008, 2010, 2015, 2016 Rocky Bernstein rocky@gnu.org
+#   Copyright (C) 2008, 2010, 2015, 2016, 2024
+#   Rocky Bernstein rocky@gnu.org
 #
 #   This program is free software; you can redistribute it and/or
 #   modify it under the terms of the GNU General Public License as
@@ -38,7 +39,7 @@ Functions and source'd files are not traced. This is in contrast to
 See also:
 ---------
 
-**skip**." 1
+**skip**, *step**, and **set force**." 1
 
 # Next command
 # $1 is command next+, next-, or next

--- a/command/step.sh
+++ b/command/step.sh
@@ -43,7 +43,7 @@ _Dbg_help_add 'step+' \
 In contrast to \"step\", we ensure that the file and line position is
 different from the last one just stopped at.
 
-See also \"step-\" and \"set force\"."
+See also \"step-\" and \"set force\"." 0
 
 _Dbg_help_add 'step-' \
 "step- -- Single step a statement without the \`step force' setting.
@@ -51,7 +51,7 @@ _Dbg_help_add 'step-' \
 Set step force may have been set on. step- ensures we turn that off for
 this command.
 
-See also \"step\" and \"set force\"."
+See also \"step\" and \"set force\"." 0
 
 # Step command
 # $1 is command step+, step-, or step
@@ -68,7 +68,7 @@ _Dbg_do_step() {
   typeset suffix
   suffix=${_Dbg_last_next_step_cmd:${#_Dbg_last_step_next_cmd}-1:1}
 
-  case "suffix" in
+  case "$suffix" in
       '+' ) _Dbg_step_force=1 ;;
       '-' ) _Dbg_step_force=0 ;;
       *   ) _Dbg_step_force=$_Dbg_set_different ;;

--- a/command/step.sh
+++ b/command/step.sh
@@ -1,21 +1,23 @@
 # -*- shell-script -*-
 # step.sh - Debugger step ("step into") commmand.
 #
-#   Copyright (C) 2006, 2008, 2009, 2010, 2015 Rocky Bernstein rocky@gnu.org
+#   Copyright (C) 2006, 2008, 2009, 2010, 2015
+#   2024 Rocky Bernstein rocky@gnu.org
 #
-#   bashdb is free software; you can redistribute it and/or modify it under
-#   the terms of the GNU General Public License as published by the Free
-#   Software Foundation; either version 2, or (at your option) any later
-#   version.
+#   This program is free software; you can redistribute it and/or
+#   modify it under the terms of the GNU General Public License as
+#   published by the Free Software Foundation; either version 2, or
+#   (at your option) any later version.
 #
-#   bashdb is distributed in the hope that it will be useful, but WITHOUT ANY
-#   WARRANTY; without even the implied warranty of MERCHANTABILITY or
-#   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
-#   for more details.
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+#   General Public License for more details.
 #
-#   You should have received a copy of the GNU General Public License along
-#   with bashdb; see the file COPYING.  If not, write to the Free Software
-#   Foundation, 59 Temple Place, Suite 330, Boston, MA 02111 USA.
+#   You should have received a copy of the GNU General Public License
+#   along with this program; see the file COPYING.  If not, write to
+#   the Free Software Foundation, 59 Temple Place, Suite 330, Boston,
+#   MA 02111 USA.
 
 # Sets whether or not to display command to be executed in debugger prompt.
 # If yes, always show. If auto, show only if the same line is to be run
@@ -25,33 +27,30 @@
 typeset -i _Dbg_set_different=0
 
 _Dbg_help_add step \
-"step [COUNT]
+"**step** [*count*]
 
 Single step an statement. This is sometimes called 'step into'.
 
 
-If COUNT is given, stepping occurs that many times before
-stopping. Otherwise COUNT is one. COUNT an be an arithmetic
+If *count* is given, stepping occurs that many times before
+stopping. Otherwise *count* is one. *count* an be an arithmetic
 expression.
 
-In contrast to \"next\", functions and source'd files are stepped
-into. See also \"skip\"."
-
-_Dbg_help_add 'step+' \
-"step+ -- Single step a statement ensuring a different line after the step.
-
-In contrast to \"step\", we ensure that the file and line position is
+If suffix \"+\" is added, we ensure that the file and line position is
 different from the last one just stopped at.
 
-See also \"step-\" and \"set force\"." 0
+However in contrast to \"next\", functions and source'd files are stepped
+into.
 
-_Dbg_help_add 'step-' \
-"step- -- Single step a statement without the \`step force' setting.
+If suffix \"-\" is added, the different line aspect of \"step+\" does not occur.
 
-Set step force may have been set on. step- ensures we turn that off for
-this command.
+With no suffix is given, the behavior is dicted by the setting of **set force**.
 
-See also \"step\" and \"set force\"." 0
+See also:
+---------
+
+**next**, **skip**, and **set force**." 1
+
 
 # Step command
 # $1 is command step+, step-, or step
@@ -92,5 +91,5 @@ _Dbg_do_step() {
 }
 
 _Dbg_alias_add 's'  'step'
-_Dbg_alias_add 's+' 'step+'
-_Dbg_alias_add 's-' 'step-'
+_Dbg_alias_add 's+'  'step+'
+_Dbg_alias_add 's-'  'step-'

--- a/lib/processor.sh
+++ b/lib/processor.sh
@@ -380,7 +380,7 @@ _Dbg_onecmd() {
 
              # single-step
              'step+' | 'step-' )
-                 _Dbg_do_step "$_Dbg_cmd" $_Dbg_args
+                 _Dbg_do_step $_Dbg_args
                  return 0
                  ;;
 

--- a/test/data/misc-output-50.right
+++ b/test/data/misc-output-50.right
@@ -67,14 +67,14 @@ POSSIBILITY OF SUCH DAMAGES.
 +help
 Available commands:
 -------------------
-  action     continue  eval     history  quit     signal  tty
-  alias      debug     examine  info     return   skip    unalias
-  backtrace  delete    export   kill     reverse  source  undisplay
-  break      disable   file     list     run      step    untrace
-  clear      display   finish   load     search   step+   up
-  commands   down      frame    next     set      step+   watch
-  complete   edit      handle   print    shell    tbreak  watche
-  condition  enable    help     pwd      show     trace
+  action     continue  eval     history  quit     signal   undisplay
+  alias      debug     examine  info     return   skip     untrace
+  backtrace  delete    export   kill     reverse  source   up
+  break      disable   file     list     run      step     watch
+  clear      display   finish   load     search   tbreak   watche
+  commands   down      frame    next     set      trace
+  complete   edit      handle   print    shell    tty
+  condition  enable    help     pwd      show     unalias
 
 Readline command line editing (emacs/vi mode) is available.
 Type "help" followed by command name for full documentation.


### PR DESCRIPTION
Fix `step+` and step- commands in bashdb.
Before, `step+` and `step-` were registered as separate commands and not as aliases. Also, the suffix matching wasn't working in `_Dbg_do_step` for suffix values `-` and `+`.