### PR TITLE
5.2: Fix pollution with global variables

### DIFF
--- a/bashdb.in
+++ b/bashdb.in
@@ -65,12 +65,12 @@ typeset -xa _Dbg_script_args; _Dbg_script_args=("$@")
 
 typeset -i _Dbg_i
 for ((_Dbg_i=0; _Dbg_i<${#_Dbg_script_args[@]}-1; _Dbg_i++)) ; do
-    typeset arg=${_Dbg_script_args[$_Dbg_i]}
-    if [[ $arg == '-L' || $arg == '--library' ]] ; then
+    typeset _Dbg_script_arg=${_Dbg_script_args[$_Dbg_i]}
+    if [[ $_Dbg_script_arg == '-L' || $_Dbg_script_arg == '--library' ]] ; then
 	((_Dbg_i++))
 	_Dbg_libdir="${_Dbg_script_args[$_Dbg_i]}"
 	break
-    elif [[ $arg == '--' ]] ; then
+    elif [[ $_Dbg_script_arg == '--' ]] ; then
 	# We hit the end of bashdb args
 	break
     fi

--- a/command/help.sh
+++ b/command/help.sh
@@ -78,8 +78,8 @@ function _Dbg_do_help {
 	if [[ -n ${_Dbg_command_help[$dbg_cmd]} ]] ; then
  	    _Dbg_msg_rst "${_Dbg_command_help[$dbg_cmd]}"
 	else
-	    _Dbg_alias_expand $dbg_cmd
-	    dbg_cmd="$expanded_alias"
+	    typeset _Dbg_expanded_alias; _Dbg_alias_expand $dbg_cmd
+	    dbg_cmd="$_Dbg_expanded_alias"
 	    if [[ -n ${_Dbg_command_help[$dbg_cmd]} ]] ; then
  		_Dbg_msg_rst "${_Dbg_command_help[$dbg_cmd]}"
 	    else

--- a/command/info.sh
+++ b/command/info.sh
@@ -39,6 +39,8 @@ _Dbg_do_info() {
       typeset subcmd=$1
       shift
 
+      typeset -i found=0
+
       if [[ -n ${_Dbg_debugger_info_commands[$subcmd]} ]] ; then
           ${_Dbg_debugger_info_commands[$subcmd]} "$@"
           return $?

--- a/command/info_sub/files.sh
+++ b/command/info_sub/files.sh
@@ -29,6 +29,7 @@ _Dbg_do_info_files() {
     typeset -a list=()
     typeset -i i=0
     typeset    key
+    typeset    file
     for key in "${!_Dbg_file2canonic[@]}"; do
 	list[$i]="$key"
 	((i++))

--- a/dbg-main.sh
+++ b/dbg-main.sh
@@ -74,12 +74,12 @@ if [[ ${_Dbg_libdir:0:1} == '.' ]] ; then
     _Dbg_libdir="$(_Dbg_expand_filename "${_Dbg_init_cwd}/${_Dbg_libdir}")"
 fi
 
-for source_file in "${_Dbg_o_init_files[@]}" "$DBG_RESTART_FILE";  do
-    if [[ -n "$source_file" ]] ; then
-	if [[ -r "$source_file" ]] && [[ -f "$source_file" ]] ; then
-	    source "$source_file"
+for _Dbg_source_file in "${_Dbg_o_init_files[@]}" "$DBG_RESTART_FILE";  do
+    if [[ -n "$_Dbg_source_file" ]] ; then
+	if [[ -r "$_Dbg_source_file" ]] && [[ -f "$_Dbg_source_file" ]] ; then
+	    source "$_Dbg_source_file"
 	else
-	    _Dbg_errmsg "Unable to read shell script: ${source_file}"
+	    _Dbg_errmsg "Unable to read shell script: ${_Dbg_source_file}"
 	fi
     fi
 done

--- a/init/vars.sh
+++ b/init/vars.sh
@@ -41,7 +41,7 @@ fi
 typeset -i _Dbg_need_input=1   # True if we need to reassign input.
 typeset -i _Dbg_brkpt_num=0    # If nonzero, the breakpoint number that we
                                # are currently stopped at.
-typeset last_next_step_cmd='s' # Default is step.
+typeset _Dbg_last_next_step_cmd=''
 typeset _Dbg_last_print=''     # expression on last print command
 typeset _Dbg_last_printe=''    # expression on last print expression command
 

--- a/lib/alias.sh
+++ b/lib/alias.sh
@@ -34,13 +34,13 @@ _Dbg_alias_remove() {
     return 0
 }
 
-# Expand alias $1. The result is set in variable expanded_alias which
+# Expand alias $1. The result is set in variable _Dbg_expanded_alias which
 # could be declared local in the caller.
 _Dbg_alias_expand() {
     (( $# != 1 )) && return 1
-    expanded_alias="$1"
+    _Dbg_expanded_alias="$1"
     [[ -z "$1" ]] && return 0
-    [[ -n ${_Dbg_aliases[$1]} ]] && expanded_alias=${_Dbg_aliases[$1]}
+    [[ -n ${_Dbg_aliases[$1]} ]] && _Dbg_expanded_alias=${_Dbg_aliases[$1]}
     return 0
 }
 

--- a/lib/complete.sh
+++ b/lib/complete.sh
@@ -26,8 +26,8 @@ typeset -a _Dbg_matches; _Dbg_matches=()
 # We get the list of completions from _Dbg._*subcmd*_cmds.
 # If no completion, we return the empty list.
 _Dbg_subcmd_complete() {
-    subcmd=$1
-    text=$2
+    typeset subcmd=$1
+    typeset text=$2
     _Dbg_matches=()
     typeset list=''
     if [[ $subcmd == 'set' ]] ; then

--- a/lib/help.sh
+++ b/lib/help.sh
@@ -44,12 +44,12 @@ function _Dbg_help_add {
 
 # Add help text $3 for in subcommand $1 under key $2
 function _Dbg_help_add_sub {
-    add_command=${4:-1}
+    typeset add_command; add_command=${4:-1}
     (($# != 3)) && (($# != 4))  && return 1
     typeset -i add_command; add_command=${4:-1}
     eval "_Dbg_command_help_$1[$2]=\"$3\""
     if (( add_command )) ; then
-	subcmd=${2//[-]/_}
+	typeset subcmd; subcmd=${2//[-]/_}
         eval "_Dbg_debugger_${1}_commands[$2]=\"_Dbg_do_${1}_${subcmd}\""
     fi
     return 0

--- a/lib/info.sh
+++ b/lib/info.sh
@@ -28,6 +28,7 @@ _Dbg_info_help() {
         typeset -a list
 	_Dbg_section 'List of info subcommands:'
 
+    typeset thing
 	for thing in $_Dbg_info_cmds ; do
 	    _Dbg_info_help $thing 1
 	done

--- a/lib/sig.sh
+++ b/lib/sig.sh
@@ -79,6 +79,7 @@ _Dbg_save_handler() {
 _Dbg_subst_handler_var() {
   typeset -i i
   typeset result=''
+  typeset arg
   for arg in $* ; do
       case $arg in
 	  '$LINENO' )

--- a/test/unit/test-alias.sh.in
+++ b/test/unit/test-alias.sh.in
@@ -3,12 +3,12 @@
 test_alias()
 {
     _Dbg_alias_add u up
-    typeset expanded_alias=''; _Dbg_alias_expand u
-    assertEquals 'up' $expanded_alias
+    typeset _Dbg_expanded_alias=''; _Dbg_alias_expand u
+    assertEquals 'up' $_Dbg_expanded_alias
 
     _Dbg_alias_add q quit
-    expanded_alias=''; _Dbg_alias_expand q
-    assertEquals 'quit' $expanded_alias
+    _Dbg_expanded_alias=''; _Dbg_alias_expand q
+    assertEquals 'quit' $_Dbg_expanded_alias
 
     typeset aliases_found=''
     _Dbg_alias_find_aliased quit
@@ -19,14 +19,14 @@ test_alias()
     assertEquals 'q, exit' "$aliases_found"
 
     _Dbg_alias_remove q
-    expanded_alias=''; _Dbg_alias_expand q
-    assertEquals 'q' $expanded_alias
+    _Dbg_expanded_alias=''; _Dbg_alias_expand q
+    assertEquals 'q' $_Dbg_expanded_alias
 
     _Dbg_alias_find_aliased quit
     assertEquals 'exit' "$aliases_found"
 
-    expanded_alias=''; _Dbg_alias_expand u
-    assertEquals 'up' $expanded_alias
+    _Dbg_expanded_alias=''; _Dbg_alias_expand u
+    assertEquals 'up' $_Dbg_expanded_alias
 }
 
 if [ '@abs_top_srcdir@' = '' ] ; then


### PR DESCRIPTION
Fixes some of the pollution with global variables.

We're dropping the default of `s`/`step` for the "last command", because it's breaking tests and is potentially confusing to users. Previously, the default was not applied because the other places used a `_Dbg_` prefix (i.e. the name here was wrong and the default was not used).