### PR TITLE
5.2: Fix highlighting on macOS

### DIFF
--- a/init/opts.sh
+++ b/init/opts.sh
@@ -130,6 +130,7 @@ _Dbg_parse_options() {
 
     typeset -i _Dbg_o_quiet=0
     typeset -i _Dbg_o_version=0
+    typeset -i _Dbg_highlight_enabled=1
 
     while getopts_long A:Bc:x:hL:nqTt:Yy:VX opt \
         annotate     required_argument       \
@@ -177,10 +178,12 @@ _Dbg_parse_options() {
 
 		if (( ! _Dbg_have_working_pygmentize )) ; then
                     printf "Can't run pygmentize. --highlight forced off" >&2
+		    _Dbg_highlight_enabled=0
 		    _Dbg_set_highlight=''
                 fi
                 ;;
             no-highlight )
+                _Dbg_highlight_enabled=0
                 _Dbg_set_highlight=''   ;;
             init-file )
                 set -x
@@ -250,25 +253,24 @@ welcome to change it and/or distribute copies of it under certain conditions.
     fi
     unset _Dbg_o_annotate _Dbg_o_version _Dbg_o_quiet
     _Dbg_script_args=("$@")
+
+    if (( _Dbg_have_working_pygmentize )) && (( _Dbg_highlight_enabled )) && [[ -z "$_Dbg_set_highlight" ]] ; then
+        # Honor DARK_BG if already set. If not set, set it.
+        if [[ -z "$DARK_BG" ]] ; then
+        . "${_Dbg_libdir}/init/term-background.sh" >/dev/null
+        fi
+
+        # DARK_BG is now either 0 or 1.
+        # Set _Dbg_set_highlight based on DARK_BG
+        # Note however that options processing has one more chance to
+        # change _Dbg_set_highlight
+        if (( $DARK_BG )); then
+        _Dbg_set_highlight="dark"
+        else
+        _Dbg_set_highlight="light"
+        fi
+    fi
 }
-
-if (( _Dbg_have_working_pygmentize )) && [[ -z "$_Dbg_set_highlight" ]] ; then
-    # Honor DARK_BG if already set. If not set, set it.
-    if [[ -z "$DARK_BG" ]] ; then
-	. "${_Dbg_libdir}/init/term-background.sh" >/dev/null
-    fi
-
-    # DARK_BG is now either 0 or 1.
-    # Set _Dbg_set_highlight based on DARK_BG
-    # Note however that options processing has one more chance to
-    # change _Dbg_set_highlight
-    if (( $DARK_BG )); then
-	_Dbg_set_highlight="dark"
-    else
-	_Dbg_set_highlight="light"
-    fi
-fi
-
 
 # Stand-alone Testing.
 if [[ -n "$_Dbg_dbg_opts_test" ]] ; then

--- a/init/term-background.sh
+++ b/init/term-background.sh
@@ -56,12 +56,13 @@ get_default_colorfgbg() {
 is_dark_rgb() {
   typeset fg_r fg_g fg_b
   typeset bg_r bg_g bg_b
-  fg_r=$1
-  fg_g=$2
-  fg_b=$3
-  bg_r=$4
-  bg_g=$5
-  bg_b=$6
+  typeset a_fg a_bg
+  fg_r=${1:-0}
+  fg_g=${2:-0}
+  fg_b=${3:-0}
+  bg_r=${4:-FF}
+  bg_g=${5:-FF}
+  bg_b=${6:-FF}
   a_fg=$((16#"$fg_r" + 16#"$fg_g" + 16#"$fg_b"))
   a_bg=$((16#"$bg_r" + 16#"$bg_g" + 16#"$bg_b"))
   if [[ $a_fg -gt $a_bg ]]; then


### PR DESCRIPTION
This is merging BashSupport Pro's patch commit to its fork: https://github.com/BashSupport-Pro/bashdb/commit/1eea0c01bbdaba0585deecfc9c61fe11640f9175?diff=unified&w=1
- It ensures that `term-background.sh` is not loaded if highlighting is disabled. The sourcing of `/init/term-background.sh` now happens when `_Dbg_parse_options` is called and not when `init/opts.sh` is sourced. But because bashdb is executing `. "${_Dbg_libdir}/init/opts.sh"; _Dbg_parse_options "$@"` this shouldn't make a difference.
- It fixes `term-background.sh` to handle undefined variables and adds missing local variable declarations.

Original commits:
* Source term-background.sh only if highlighting is enabled. https://github.com/BashSupport-Pro/bashsupport-pro/issues/66
* Add safe fallback values in case parameters are not defined. https://github.com/BashSupport-Pro/bashsupport-pro/issues/66