### PR TITLE
4.4: Fix highlighting on macOS 

### DIFF
--- a/init/opts.sh
+++ b/init/opts.sh
@@ -129,6 +129,7 @@ _Dbg_parse_options() {
 
     typeset -i _Dbg_o_quiet=0
     typeset -i _Dbg_o_version=0
+    typeset -i _Dbg_highlight_enabled=1
 
     while getopts_long A:Bc:x:hL:nqTt:Yy:VX opt \
         annotate     required_argument       \
@@ -176,10 +177,12 @@ _Dbg_parse_options() {
 
 		if (( ! _Dbg_have_working_pygmentize )) ; then
                     printf "Can't run pygmentize. --highlight forced off" >&2
+            _Dbg_highlight_enabled=0
 		    _Dbg_set_highlight=''
                 fi
                 ;;
             no-highlight )
+                _Dbg_highlight_enabled=0
                 _Dbg_set_highlight=''   ;;
             init-file )
                 set -x
@@ -249,25 +252,24 @@ welcome to change it and/or distribute copies of it under certain conditions.
     fi
     unset _Dbg_o_annotate _Dbg_o_version _Dbg_o_quiet
     _Dbg_script_args=("$@")
+
+    if (( _Dbg_have_working_pygmentize )) && (( _Dbg_highlight_enabled )) && [[ -z "$_Dbg_set_highlight" ]] ; then
+        # Honor DARK_BG if already set. If not set, set it.
+        if [[ -z "$DARK_BG" ]] ; then
+        . "${_Dbg_libdir}/init/term-background.sh" >/dev/null
+        fi
+
+        # DARK_BG is now either 0 or 1.
+        # Set _Dbg_set_highlight based on DARK_BG
+        # Note however that options processing has one more chance to
+        # change _Dbg_set_highlight
+        if (( $DARK_BG )); then
+        _Dbg_set_highlight="dark"
+        else
+        _Dbg_set_highlight="light"
+        fi
+    fi
 }
-
-if (( _Dbg_have_working_pygmentize )) && [[ -z "$_Dbg_set_highlight" ]] ; then
-    # Honor DARK_BG if already set. If not set, set it.
-    if [[ -z "$DARK_BG" ]] ; then
-	. "${_Dbg_libdir}/init/term-background.sh" >/dev/null
-    fi
-
-    # DARK_BG is now either 0 or 1.
-    # Set _Dbg_set_highlight based on DARK_BG
-    # Note however that options processing has one more chance to
-    # change _Dbg_set_highlight
-    if (( $DARK_BG )); then
-	_Dbg_set_highlight="dark"
-    else
-	_Dbg_set_highlight="light"
-    fi
-fi
-
 
 # Stand-alone Testing.
 if [[ -n "$_Dbg_dbg_opts_test" ]] ; then

--- a/init/term-background.sh
+++ b/init/term-background.sh
@@ -59,7 +59,7 @@ get_default_bg() {
 # On return, variable is_dark_bg is set
 is_dark_rgb() {
     typeset r g b
-    r=$1; g=$2; b=$3
+    r=${1:-FF}; g=${2:-FF}; b=${3:-FF}
     if (( (16#$r + 16#$g + 16#$b) < $TERMINAL_COLOR_MIDPOINT )) ; then
 	is_dark_bg=1
     else


### PR DESCRIPTION
This is merging BashSupport Pro's patch commit to its fork: https://github.com/BashSupport-Pro/bashdb/commit/a9ef0772dbe2c761cf5e8614ceb82ab19f0cf0af

It ensures that term-background.sh is not loaded if highlighting is disabled.
It fixes term-background.sh to handle undefined variables and adds missing local variable declarations.

* Source term-background.sh only if highlighting is enabled. https://github.com/BashSupport-Pro/bashsupport-pro/issues/66
* Add safe fallback values in case parameters are not defined. https://github.com/BashSupport-Pro/bashsupport-pro/issues/66