### PR TITLE
GitHub Actions for bash-4.4

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,28 @@
+name: "bashdb CI"
+on:
+  push:
+
+jobs:
+  linux:
+    name: "Linux"
+    runs-on: ubuntu-latest
+    container: bash:4.4
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Packages
+        shell: bash
+        run: |+
+          apk update
+          apk add build-base automake autoconf libtool texinfo
+
+      - name: Configure
+        shell: bash
+        run: bash ./autogen.sh
+
+      - name: Test
+        shell: bash
+        env:
+          VERBOSE: 1
+        run: make -e -j3 check


### PR DESCRIPTION
Adds a GitHub Actions workflow, which is executing the tests of bashdb in the official `bash:4.4` Docker container (based on Alpine Linux, https://hub.docker.com/_/bash).
We're not using the Ubuntu host because installing an older version of Bash would make a mess (probably).

When this is merged, I'll do this for bash-5.1, too.