### PR TITLE
Sync 5.1 with 5.2

### DIFF
--- a/acinclude.m4
+++ b/acinclude.m4
@@ -3,7 +3,7 @@ dnl Allow choosing the package name to avoid clashes with
 dnl bash if beeing installed side-by-side
 AC_ARG_VAR(
        ALT_PACKAGE_NAME,
-       AC_HELP_STRING([],[alternate packagename to use (default is "$1")])
+       AS_HELP_STRING([],[alternate packagename to use (default is "$1")])
 )
 if test -z "${ALT_PACKAGE_NAME}"; then
        ALT_PACKAGE_NAME="$PACKAGE_NAME"

--- a/test/example/bug-loc.sh
+++ b/test/example/bug-loc.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Bug is that file cache highlight isn't updated when when
+# Bug is that file cache highlight isn't updated when
 # it is already cached so it continues to refer to a line in the source'd file
 # rather than file it was source'd from (here it is this file).
 dirname=${BASH_SOURCE%/*}   # equivalent to dirname($0)

--- a/test/integration/test-bug-loc
+++ b/test/integration/test-bug-loc
@@ -10,7 +10,21 @@ debugged_script="$top_srcdir/test/example/bug-loc.sh"
 
 if ( pygmentize --version || pygmentize -V ) 2>/dev/null 1>/dev/null ; then
     run_debugger_opts="-B -q --no-init --highlight=light"
-    run_test_check $TEST_NAME $TEST_NAME $debugged_script
+    (cd $srcdir && run_debugger "$debugged_script" 2>&1 >"$TEST_FILE" </dev/null)
+
+    # We're removing highlighted lines because Pygments is often changing the highlighting
+    /usr/bin/grep -v -E "^[0-9]+:"$'\t' "$TEST_FILE" >"${TEST_FILTERED_FILE}"
+    /usr/bin/grep -v -E "^[0-9]+:"$'\t' "$RIGHT_FILE" >"${RIGHT_FILTERED_FILE}"
+
+    check_output "$TEST_FILTERED_FILE" "$RIGHT_FILTERED_FILE"
+    rc=$?
+    if ((0 == rc)) ; then
+      rm -f $TEST_FILTERED_FILE
+      rm -f $RIGHT_FILTERED_FILE
+    fi
+
+    # Return code tells testing mechanism whether passed or not.
+    exit $rc
 else
     exit 77
 fi


### PR DESCRIPTION
Recent changes from bash-5.2 branch

*  Don't compare unstable highlighting of Pygments, but only the file locations
* AC_HELP_STRING is obsolete. run autoupdate on acinclude.m4
* Disable highlighting of first command to fix test-settrace
