### PR TITLE
Run GitHub Actions workflow on Linux and macOS

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -3,22 +3,37 @@ on:
   push:
 
 jobs:
-  linux:
-    name: "Linux"
-    runs-on: ubuntu-latest
+  tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+    name: "Run Tests on ${{ matrix.os }}"
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Packages
+      - name: Install dependencies for Linux
+        if: runner.os == 'Linux'
         shell: bash
         run: |+
           sudo apt -y update
           sudo apt -y install autoconf automake texinfo
 
+      - name: Install dependencies for macOS
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |+
+          brew update
+          brew install bash
+          brew install autoconf automake texinfo
+          # Not installing pygments, because apparently 'osascript' executed during bashdb's init is blocking
+          # if there's not user logged in.
+
       - name: Configure
         shell: bash
-        run: sh ./autogen.sh
+        run: bash ./autogen.sh
 
       - name: Test
         shell: bash


### PR DESCRIPTION
This PR extends the GitHub Actions workflow for 5.2 execute on macOS and Linux.
Even though macOS only has bash 3.x by default, AFAIK manu use Homebrew to install and use a recent version Bash.

With this matrix build setup, the CI runtime is still under one minute: https://github.com/rocky/bashdb/actions/runs/9548882962

This PR is not installing pygments because an [attempt failed](https://github.com/rocky/bashdb/actions/runs/9548446442) due to excessive runtime. When I debugged this on a local macOS setup via ssh, running bashdb's `osascript -e 'tell application "Terminal" to get the background color of the current settings of the selected tab of front window'` did not return unless there was a logged in user session. I'm not able to reproduce this reliably in different sessions and across restarts, though.