### PR TITLE
Add `sort_list_named` to sort an array variable in-place via nameref

### DIFF
--- a/lib/sort.sh
+++ b/lib/sort.sh
@@ -8,30 +8,42 @@
 sort_list() {
   (($# != 2)) && return 1
   typeset -i left=$1
-  ((left < 0)) || (( 0 == ${#list[@]})) && return 2
+  ((left < 0)) || ((0 == ${#list[@]})) && return 2
   typeset -i right=$2
   ((right >= ${#list[@]})) && return 3
-  typeset -i i=$left; typeset -i j=$right
-  typeset -i mid; ((mid= (left+right) / 2))
-  typeset partition_item; partition_item="${list[$mid]}"
+  typeset -i i=$left
+  typeset -i j=$right
+  typeset -i mid
+  ((mid = (left + right) / 2))
+  typeset partition_item
+  partition_item="${list[$mid]}"
   typeset temp
-  while ((j > i)) ; do
-      item=${list[i]}
-      while [[ "${list[$i]}" < "$partition_item" ]] ; do
-	  ((i++))
-      done
-      while [[ "${list[$j]}" > "$partition_item" ]] ; do
-	  ((j--))
-      done
-      if ((i <= j)) ; then
-	  temp="${list[$i]}"; list[$i]="${list[$j]}"; list[$j]="$temp"
-          ((i++))
-          ((j--))
-      fi
+  while ((j > i)); do
+    item=${list[i]}
+    while [[ "${list[$i]}" < "$partition_item" ]]; do
+      ((i++))
+    done
+    while [[ "${list[$j]}" > "$partition_item" ]]; do
+      ((j--))
+    done
+    if ((i <= j)); then
+      temp="${list[$i]}"
+      list[$i]="${list[$j]}"
+      list[$j]="$temp"
+      ((i++))
+      ((j--))
+    fi
   done
-  ((left < j))  && sort_list $left  $j  
+  ((left < j)) && sort_list $left $j
   ((right > i)) && sort_list $i $right
   return 0
+}
+
+# Sorts the array variable passed as 1st parameter from index $2 to index $3.
+sort_list_named() {
+  (($# != 3)) && return 1
+  typeset -n list="$1"
+  sort_list "$2" "$3"
 }
 
 if [[ $0 == *sorting.sh ]] ; then 

--- a/test/unit/test-sort.sh.in
+++ b/test/unit/test-sort.sh.in
@@ -45,6 +45,18 @@ test_sort()
     assertNotEquals "0" "$?"
 }
 
+test_sort_named() {
+    local LC_ALL=C # for predictable sort order
+    typeset -a my_expected=(1 2 3 A B X b y z)
+
+    typeset -a my_data=(z b y 2 3 1 X A B)
+    sort_list_named my_data 0 ${#my_data[@]}-1
+    assertEquals "sort_list_named must complete successfully" 0 $?
+
+    for ((i=0; i < ${#my_expected[@]}; i++)); do
+        assertEquals "Expected sorted data at index $i." "${my_expected[i]}" "${my_data[i]}"
+    done
+}
 
 if [ '@abs_top_srcdir@' = '' ] ; then
   echo "Something is wrong abs_top_srcdir is not set."


### PR DESCRIPTION
The added function `sort_list_named` uses a namref variable to reference a variable by name, given by `$1`. 
This avoids the requirement of a global "list" variable, because `list` is only local in `sort_list_named`.

I'm planning to use this in https://github.com/rocky/bashdb/pull/23 to sort the output of `info variables`.

I passed the sort.sh through shfmt, which explains the changes to formatting. Let me know if I should revert this.