### PR TITLE
Don't assume Bash flags for BASH_REMATCH

### DIFF
--- a/test/data/bash-rematch.cmd
+++ b/test/data/bash-rematch.cmd
@@ -9,7 +9,7 @@ c
 s
 c
 s
-eval typeset -p BASH_REMATCH
+eval typeset | grep -E '^BASH_REMATCH='
 c
 s
 c

--- a/test/data/bash-rematch.right
+++ b/test/data/bash-rematch.right
@@ -30,8 +30,8 @@ Breakpoint 1 hit (2 times).
 (bash-rematch.sh:8):
 8:	    echo "${!i} matches"
  0: $BASH_REMATCH = 456
-+eval typeset -p BASH_REMATCH
-declare -a BASH_REMATCH=([0]="456")
++eval typeset | grep -E '^BASH_REMATCH='
+BASH_REMATCH=([0]="456")
 $? is 0
 +c
 456 matches


### PR DESCRIPTION
This makes the test work with all versions of Bash 5.x.

With BashSupport Pro, I'm bundling bashdb-5.2 and use it for all versions of Bash 5.x. 
That's working good so far. 

This PR drops the assumption of specific flags for BASH_REMATCH. Bash 5.0 prints `declare -ar BASH_REMATCH=()` and newer versions dropped the read-only flag.
This test shouldn't make things worse and merging back into bashdb-5.0 will a bit easier to handle .