### PR TITLE
Alias: fix pollution with global variables and sort output

### DIFF
--- a/command/help.sh
+++ b/command/help.sh
@@ -116,11 +116,12 @@ function _Dbg_do_help {
 		esac
 	    fi
 	fi
-	aliases_found=''
+
+	declare _Dbg_aliases_found=''
 	_Dbg_alias_find_aliased "$dbg_cmd"
-	if [[ -n $aliases_found ]] ; then
+	if [[ -n $_Dbg_aliases_found ]] ; then
 	    _Dbg_msg ''
-	    _Dbg_msg "Aliases for $dbg_cmd: $aliases_found"
+	    _Dbg_msg "Aliases for $dbg_cmd: $_Dbg_aliases_found"
 	fi
 	return 2
     fi

--- a/lib/alias.sh
+++ b/lib/alias.sh
@@ -58,15 +58,16 @@ _Dbg_alias_find_index() {
 # Return in help_aliases an array of strings that are aliases
 # of $1
 _Dbg_alias_find_aliased() {
-    (($# != 1)) &&  return 255
-    typeset find_name=$1
-    aliases_found=''
-    typeset -i i
-    for alias in "${!_Dbg_aliases[@]}" ; do
-	if [[ ${_Dbg_aliases[$alias]} == "$find_name" ]] ; then
-	    [[ -n $aliases_found ]] && aliases_found+=', '
-	    aliases_found+="$alias"
-	fi
+    (($# != 1)) && return 255
+    typeset _Dbg_find_name=$1
+    _Dbg_aliases_found=''
+    typeset list=("${!_Dbg_aliases[@]}")
+    sort_list 0 ${#list[@]}-1
+    for _Dbg_alias in "${list[@]}"; do
+        if [[ ${_Dbg_aliases[$_Dbg_alias]} == "$_Dbg_find_name" ]]; then
+            [[ -n $_Dbg_aliases_found ]] && _Dbg_aliases_found+=', '
+            _Dbg_aliases_found+="$_Dbg_alias"
+        fi
     done
     return 0
 }

--- a/test/unit/test-alias.sh.in
+++ b/test/unit/test-alias.sh.in
@@ -10,20 +10,20 @@ test_alias()
     _Dbg_expanded_alias=''; _Dbg_alias_expand q
     assertEquals 'quit' $_Dbg_expanded_alias
 
-    typeset aliases_found=''
+    typeset _Dbg_aliases_found=''
     _Dbg_alias_find_aliased quit
-    assertEquals 'q' "$aliases_found"
+    assertEquals 'q' "$_Dbg_aliases_found"
 
     _Dbg_alias_add exit quit
     _Dbg_alias_find_aliased quit
-    assertEquals 'q, exit' "$aliases_found"
+    assertEquals 'exit, q' "$_Dbg_aliases_found"
 
     _Dbg_alias_remove q
     _Dbg_expanded_alias=''; _Dbg_alias_expand q
     assertEquals 'q' $_Dbg_expanded_alias
 
     _Dbg_alias_find_aliased quit
-    assertEquals 'exit' "$aliases_found"
+    assertEquals 'exit' "$_Dbg_aliases_found"
 
     _Dbg_expanded_alias=''; _Dbg_alias_expand u
     assertEquals 'up' $_Dbg_expanded_alias
@@ -39,5 +39,6 @@ abs_top_srcdir=${abs_top_srcdir%%/}/
 . ${abs_top_srcdir}test/unit/helper.sh
 . $abs_top_srcdir/lib/help.sh
 . $abs_top_srcdir/lib/alias.sh
+. $abs_top_srcdir/lib/sort.sh
 set -- # reset $# so shunit2 doesn't get confused.
 [[ @CMDLINE_INVOKED@ ]] && . ${shunit_file}


### PR DESCRIPTION
In `_Dbg_alias_find_aliased` use `_Dbg_` variable names.

Also, on't assume sorted keys of Bash associative arrays.
The manual sorting lets this test run on all versions of Bash 5.x.

This will make merging a bit easier.
And it'll help BashSupport Pro's rebasing/merging, too :)