### PR TITLE
load: fix pollution of global variables, better handling of files with spaces

### DIFF
--- a/command/load.sh
+++ b/command/load.sh
@@ -39,21 +39,22 @@ _Dbg_do_load() {
     return 1
   fi
 
-  typeset filename="$(_Dbg_unescape_arg "$1")"
-  local  full_filename=$(_Dbg_resolve_expand_filename "$filename")
-  if [ -n "$full_filename" ] && [ -r "$full_filename" ] ; then
+  typeset _Dbg_filename="$(_Dbg_unescape_arg "$1")"
+  typeset _Dbg_full_filename=$(_Dbg_resolve_expand_filename "$_Dbg_filename")
+  if [ -n "$_Dbg_full_filename" ] && [ -r "$_Dbg_full_filename" ] ; then
     # Have we already loaded in this file?
-    for file in ${_Dbg_filenames[@]} ; do
-       if [[ $file == $full_filename ]] ; then
-         _Dbg_msg "File $full_filename already loaded."
+    typeset _Dbg_file
+    for _Dbg_file in "${_Dbg_filenames[@]}" ; do
+       if [[ "$_Dbg_file" == "$_Dbg_full_filename" ]] ; then
+         _Dbg_msg "File $_Dbg_full_filename already loaded."
 	 return 2
        fi
     done
 
-    _Dbg_readin "$full_filename"
-    _Dbg_msg "File $full_filename loaded."
+    _Dbg_readin "$_Dbg_full_filename"
+    _Dbg_msg "File $_Dbg_full_filename loaded."
   else
-      _Dbg_errmsg "Couldn't resolve or read $filename"
+      _Dbg_errmsg "Couldn't resolve or read $_Dbg_filename"
       return 3
   fi
   return 0


### PR DESCRIPTION
Same as https://github.com/rocky/bashdb/pull/28, but for bash-4.4