### PR TITLE
Fix pollution with global variables by getopts_long

### DIFF
--- a/bashdb-part2.sh
+++ b/bashdb-part2.sh
@@ -30,6 +30,7 @@
 # I don't know why when this is done in dbg-opts.sh it doesn't have
 # an effect.
 ((OPTLIND > 0)) && shift "$((OPTLIND - 1))"
+unset OPTLIND
 
 if (($# == 0)) && [[ -z "$_Dbg_EXECUTION_STRING" ]] ; then
     echo >&2 "${_Dbg_pname}: need to give a script to debug or use the -c option."

--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -74,7 +74,9 @@ function _Dbg_do_backtrace {
     _Dbg_not_running && return 3
 
     typeset -i show_source=0
-    OPTLIND=''
+    typeset -i OPTLIND=1
+    typeset OPTLARG OPTLERR OPTLPENDING opt
+
     while getopts_long sh opt  \
         source no_argument     \
         help no_argument       \

--- a/command/shell.sh
+++ b/command/shell.sh
@@ -62,7 +62,9 @@ in the trap EXIT of the shell.
 "
 
 _Dbg_parse_shell_cmd_options() {
-    OPTLIND=''
+    typeset -i OPTLIND=1
+    typeset OPTLARG OPTLERR OPTLPENDING opt
+
     while getopts_long lFV opt  \
 	no-fns  0               \
         posix   no_argument     \

--- a/init/opts.sh
+++ b/init/opts.sh
@@ -130,6 +130,7 @@ _Dbg_parse_options() {
     typeset -i _Dbg_o_quiet=0
     typeset -i _Dbg_o_version=0
     typeset -i _Dbg_highlight_enabled=1
+    typeset OPTLARG OPTLERR OPTLPENDING opt
 
     while getopts_long A:Bc:x:hL:nqTt:Yy:VX opt \
         annotate     required_argument       \


### PR DESCRIPTION
Same as https://github.com/rocky/bashdb/pull/33, but for bash-4.4