### PR TITLE
5.2: Avoid pollution with global variables

### DIFF
--- a/command/break.sh
+++ b/command/break.sh
@@ -150,7 +150,7 @@ _Dbg_do_clear_brkpt() {
 # If $1 is given just list those associated for that line.
 _Dbg_do_list_brkpt() {
 
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     if (( $# != 0  )) ; then
 	typeset brkpt_num="$1"
 	if [[ $brkpt_num != $_Dbg_int_pat ]]; then

--- a/command/break.sh
+++ b/command/break.sh
@@ -171,7 +171,7 @@ _Dbg_do_list_brkpt() {
 	    fi
 	    _Dbg_print_brkpt_count ${_Dbg_brkpt_count[$i]}
 	fi
-	eval "$_resteglob"
+	eval "$_Dbg_resteglob"
 	return 0
     elif (( ${#_Dbg_brkpt_line[@]} != 0 )); then
 	typeset -i i

--- a/command/break.sh
+++ b/command/break.sh
@@ -153,7 +153,7 @@ _Dbg_do_list_brkpt() {
     eval "$_seteglob"
     if (( $# != 0  )) ; then
 	typeset brkpt_num="$1"
-	if [[ $brkpt_num != $int_pat ]]; then
+	if [[ $brkpt_num != $_Dbg_int_pat ]]; then
 	    _Dbg_errmsg "Bad breakpoint number $brkpt_num."
 	elif [[ -z "${_Dbg_brkpt_file[$brkpt_num]}" ]] ; then
 	    _Dbg_errmsg "Breakpoint entry $brkpt_num is not set."

--- a/command/commands.sh
+++ b/command/commands.sh
@@ -35,7 +35,7 @@ _Dbg_do_commands() {
   typeset num=$1
   typeset -i found=0
   case $num in
-      $int_pat )
+      $_Dbg_int_pat )
 	  if [[ -z "${_Dbg_brkpt_file[$num]}" ]] ; then
 	      _Dbg_errmsg "No breakpoint number $num."
 	      return 1

--- a/command/commands.sh
+++ b/command/commands.sh
@@ -45,7 +45,7 @@ _Dbg_do_commands() {
       * )
 	_Dbg_errmsg "Invalid entry number skipped: $num"
   esac
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
   if (( found )) ; then 
       _Dbg_brkpt_commands_defining=1
       _Dbg_brkpt_commands_current=$num

--- a/command/commands.sh
+++ b/command/commands.sh
@@ -31,7 +31,7 @@ Type a line containing "end" to indicate the end of them.  Give
 output is printed when it is hit, except what the commands print.'
 
 _Dbg_do_commands() {
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   typeset num=$1
   typeset -i found=0
   case $num in

--- a/command/condition.sh
+++ b/command/condition.sh
@@ -53,7 +53,7 @@ function _Dbg_do_condition {
   shift
 
   eval "$_seteglob"
-  if [[ $n != $int_pat ]]; then
+  if [[ $n != $_Dbg_int_pat ]]; then
     eval "$_resteglob"
     _Dbg_errmsg "condition: Bad breakpoint number: $n"
     return 2

--- a/command/condition.sh
+++ b/command/condition.sh
@@ -54,11 +54,11 @@ function _Dbg_do_condition {
 
   eval "$_seteglob"
   if [[ $n != $_Dbg_int_pat ]]; then
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     _Dbg_errmsg "condition: Bad breakpoint number: $n"
     return 2
   fi
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
 
   if [[ -z "${_Dbg_brkpt_file[$n]}" ]] ; then
     _Dbg_msg "condition: Breakpoint entry $n is not set. Condition not changed."

--- a/command/condition.sh
+++ b/command/condition.sh
@@ -52,7 +52,7 @@ function _Dbg_do_condition {
   typeset -r n=$1
   shift
 
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   if [[ $n != $_Dbg_int_pat ]]; then
     eval "$_Dbg_resteglob"
     _Dbg_errmsg "condition: Bad breakpoint number: $n"

--- a/command/debug.sh
+++ b/command/debug.sh
@@ -48,7 +48,7 @@ _Dbg_do_debug() {
 
     [[ -z $BASH ]] && BASH='bash'
 
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     # Add appropriate bash debugging options
     if (( ! _Dbg_script )) ; then
 	# Running "bash --debugger", so prepend "bash --debugger"

--- a/command/debug.sh
+++ b/command/debug.sh
@@ -57,7 +57,7 @@ _Dbg_do_debug() {
 	# Running "bashdb", so prepend "bash bashdb .."
 	set_Dbg_debug_cmd="typeset _Dbg_debug_cmd=\"$BASH $_Dbg_orig_0 -q -L $_Dbg_libdir $script_cmd\"";
     fi
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     eval $set_Dbg_debug_cmd
 
     if (( _Dbg_set_basename )) ; then

--- a/command/delete.sh
+++ b/command/delete.sh
@@ -48,7 +48,7 @@ _Dbg_do_delete() {
       fi
   fi
 
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   for del in $to_go ; do
     case $del in
       $_Dbg_watch_pat )

--- a/command/delete.sh
+++ b/command/delete.sh
@@ -54,7 +54,7 @@ _Dbg_do_delete() {
       $_Dbg_watch_pat )
           _Dbg_delete_watch_entry ${del:0:${#del}-1}
           ;;
-      $int_pat )
+      $_Dbg_int_pat )
           if _Dbg_delete_brkpt_entry $del ; then
 	      _Dbg_msg "Deleted breakpoint ${del}"
 	      ((tot_found++))

--- a/command/delete.sh
+++ b/command/delete.sh
@@ -64,7 +64,7 @@ _Dbg_do_delete() {
         _Dbg_errmsg "Invalid entry number skipped: $del"
     esac
   done
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
   return $tot_found
 }
 

--- a/command/handle.sh
+++ b/command/handle.sh
@@ -46,7 +46,7 @@ _Dbg_do_handle() {
     return 1
     fi
 
-    if [[ $sig == $int_pat ]]; then
+    if [[ $sig == $_Dbg_int_pat ]]; then
 	signame=$(_Dbg_signum2name $sig)
 	if (( $? != 0 )) ; then
 	    _Dbg_errmsg "Bad signal number: $sig"

--- a/command/history.sh
+++ b/command/history.sh
@@ -52,7 +52,7 @@ _Dbg_do_history() {
 # $2 is where to stop or 0 if not given.
 _Dbg_do_history_list() {
 
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   if [[ $1 != $_Dbg_int_pat ]] && [[ $1 != -$_Dbg_int_pat ]] && [[ -n $1 ]] ; then
     _Dbg_msg "Invalid history number: $1"
     eval "$_Dbg_resteglob"

--- a/command/history.sh
+++ b/command/history.sh
@@ -55,10 +55,10 @@ _Dbg_do_history_list() {
   eval "$_seteglob"
   if [[ $1 != $_Dbg_int_pat ]] && [[ $1 != -$_Dbg_int_pat ]] && [[ -n $1 ]] ; then
     _Dbg_msg "Invalid history number: $1"
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return 1
   fi
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
 
   _Dbg_hi=${#_Dbg_history[@]}
   local -i n=${1:-$_Dbg_hi-1}

--- a/command/history.sh
+++ b/command/history.sh
@@ -53,7 +53,7 @@ _Dbg_do_history() {
 _Dbg_do_history_list() {
 
   eval "$_seteglob"
-  if [[ $1 != $int_pat ]] && [[ $1 != -$int_pat ]] && [[ -n $1 ]] ; then
+  if [[ $1 != $_Dbg_int_pat ]] && [[ $1 != -$_Dbg_int_pat ]] && [[ -n $1 ]] ; then
     _Dbg_msg "Invalid history number: $1"
     eval "$_resteglob"
     return 1

--- a/command/info.sh
+++ b/command/info.sh
@@ -36,32 +36,32 @@ _Dbg_complete_info() {
 _Dbg_do_info() {
 
   if (($# > 0)) ; then
-      typeset subcmd=$1
+      typeset _Dbg_subcmd=$1
       shift
 
-      typeset -i found=0
+      typeset -i _Dbg_found=0
 
-      if [[ -n ${_Dbg_debugger_info_commands[$subcmd]} ]] ; then
-          ${_Dbg_debugger_info_commands[$subcmd]} "$@"
+      if [[ -n ${_Dbg_debugger_info_commands[$_Dbg_subcmd]} ]] ; then
+          ${_Dbg_debugger_info_commands[$_Dbg_subcmd]} "$@"
           return $?
       else
           # Look for a unique abbreviation
-          typeset -i count=0
-          typeset list; list="${!_Dbg_debugger_info_commands[@]}"
-          for try in $list ; do
-              if [[ $try =~ ^$subcmd ]] ; then
-                  subcmd=$try
-                  ((count++))
+          typeset -i _Dbg_count=0
+          typeset _Dbg_list; _Dbg_list="${!_Dbg_debugger_info_commands[@]}"
+          for _Dbg_try in $_Dbg_list ; do
+              if [[ $_Dbg_try =~ ^$_Dbg_subcmd ]] ; then
+                  _Dbg_subcmd="$_Dbg_try"
+                  ((_Dbg_count++))
               fi
           done
-          ((found=(count==1)))
+          ((_Dbg_found=(_Dbg_count==1)))
       fi
-      if ((found)); then
-          ${_Dbg_debugger_info_commands[$subcmd]} "$@"
+      if ((_Dbg_found)); then
+          ${_Dbg_debugger_info_commands[$_Dbg_subcmd]} "$@"
           return $?
       fi
 
-      _Dbg_errmsg "Unknown info subcommand: $subcmd"
+      _Dbg_errmsg "Unknown info subcommand: $_Dbg_subcmd"
       msg=_Dbg_errmsg
   else
       msg=_Dbg_msg

--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -47,7 +47,7 @@ _Dbg_do_info_args() {
     typeset -r frame_start=${1:-0}
 
     eval "$_seteglob"
-    if [[ $frame_start != $int_pat ]] ; then
+    if [[ $frame_start != $_Dbg_int_pat ]] ; then
 	_Dbg_errmsg "Bad integer parameter: $frame_start"
 	eval "$_resteglob"
 	return 1

--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -46,7 +46,7 @@ _Dbg_do_info_args() {
 
     typeset -r frame_start=${1:-0}
 
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     if [[ $frame_start != $_Dbg_int_pat ]] ; then
 	_Dbg_errmsg "Bad integer parameter: $frame_start"
 	eval "$_Dbg_resteglob"

--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -49,7 +49,7 @@ _Dbg_do_info_args() {
     eval "$_seteglob"
     if [[ $frame_start != $_Dbg_int_pat ]] ; then
 	_Dbg_errmsg "Bad integer parameter: $frame_start"
-	eval "$_resteglob"
+	eval "$_Dbg_resteglob"
 	return 1
     fi
 

--- a/command/search.sh
+++ b/command/search.sh
@@ -46,7 +46,7 @@ _Dbg_do_reverse() {
   typeset -i i
   for (( i=_Dbg_listline-1; i > 0 ; i-- )) ; do
     _Dbg_get_source_line $i "$_Dbg_frame_last_filename"
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     if [[ $_Dbg_source_line == *$_Dbg_last_search_pat* ]] ; then
       eval "$_Dbg_resteglob"
       _Dbg_do_list $i 1
@@ -91,7 +91,7 @@ _Dbg_do_search() {
   typeset -i i
   for (( i=_Dbg_listline+1; i < max_line ; i++ )) ; do
     _Dbg_get_source_line $i "$_Dbg_frame_last_filename"
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     if [[ $_Dbg_source_line == *$_Dbg_last_search_pat* ]] ; then
       eval "$_Dbg_resteglob"
       _Dbg_do_list $i 1

--- a/command/search.sh
+++ b/command/search.sh
@@ -48,13 +48,13 @@ _Dbg_do_reverse() {
     _Dbg_get_source_line $i "$_Dbg_frame_last_filename"
     eval "$_seteglob"
     if [[ $_Dbg_source_line == *$_Dbg_last_search_pat* ]] ; then
-      eval "$_resteglob"
+      eval "$_Dbg_resteglob"
       _Dbg_do_list $i 1
       _Dbg_listline=$i
       _Dbg_last_cmd='search'
       return 0
     fi
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
   done
   _Dbg_msg "search pattern: $_Dbg_last_search_pat not found."
   return 1
@@ -93,13 +93,13 @@ _Dbg_do_search() {
     _Dbg_get_source_line $i "$_Dbg_frame_last_filename"
     eval "$_seteglob"
     if [[ $_Dbg_source_line == *$_Dbg_last_search_pat* ]] ; then
-      eval "$_resteglob"
+      eval "$_Dbg_resteglob"
       _Dbg_do_list $i 1
       _Dbg_listline=$i
       # _Dbg_last_cmd='/'
       return 0
     fi
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
   done
   _Dbg_errmsg "search pattern: $_Dbg_last_search_pat not found."
   return 1

--- a/command/set_sub/annotate.sh
+++ b/command/set_sub/annotate.sh
@@ -44,10 +44,10 @@ _Dbg_do_set_annotate() {
 	    _Dbg_write_journal_eval "_Dbg_set_annotate=$1"
 	fi
     else
-	eval "$_resteglob"
+	eval "$_Dbg_resteglob"
 	_Dbg_msg "Integer argument expected; got: $1"
 	return 1
     fi
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return 0
 }

--- a/command/set_sub/annotate.sh
+++ b/command/set_sub/annotate.sh
@@ -34,7 +34,7 @@ See also:
 ' 1
 
 _Dbg_do_set_annotate() {
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     if (( $# != 1 )) ; then
 	_Dbg_msg "A single argument is required (got $# arguments)."
     elif [[ $1 == $_Dbg_int_pat ]] ; then

--- a/command/set_sub/annotate.sh
+++ b/command/set_sub/annotate.sh
@@ -37,7 +37,7 @@ _Dbg_do_set_annotate() {
     eval "$_seteglob"
     if (( $# != 1 )) ; then
 	_Dbg_msg "A single argument is required (got $# arguments)."
-    elif [[ $1 == $int_pat ]] ; then
+    elif [[ $1 == $_Dbg_int_pat ]] ; then
 	if (( $1 > 3 )) ; then
 	    _Dbg_msg "Annotation level must be between 0 and 3. Got: ${1}."
 	else

--- a/command/set_sub/history.sh
+++ b/command/set_sub/history.sh
@@ -61,10 +61,10 @@ _Dbg_do_set_history() {
                 _Dbg_errmsg "Argument required (integer to set it to.)."
             elif [[ $2 != $_Dbg_int_pat ]] ; then
                 _Dbg_errmsg "Integer argument expected; got: $2"
-                eval "$_resteglob"
+                eval "$_Dbg_resteglob"
                 return 1
             fi
-            eval "$_resteglob"
+            eval "$_Dbg_resteglob"
             _Dbg_write_journal_eval "_Dbg_history_length=$2"
             ;;
         *)

--- a/command/set_sub/history.sh
+++ b/command/set_sub/history.sh
@@ -56,7 +56,7 @@ _Dbg_do_set_history() {
             esac
             ;;
         si | siz | size )
-            eval "$_seteglob"
+            eval "$_Dbg_seteglob"
             if [[ -z $2 ]] ; then
                 _Dbg_errmsg "Argument required (integer to set it to.)."
             elif [[ $2 != $_Dbg_int_pat ]] ; then

--- a/command/set_sub/history.sh
+++ b/command/set_sub/history.sh
@@ -59,7 +59,7 @@ _Dbg_do_set_history() {
             eval "$_seteglob"
             if [[ -z $2 ]] ; then
                 _Dbg_errmsg "Argument required (integer to set it to.)."
-            elif [[ $2 != $int_pat ]] ; then
+            elif [[ $2 != $_Dbg_int_pat ]] ; then
                 _Dbg_errmsg "Integer argument expected; got: $2"
                 eval "$_resteglob"
                 return 1

--- a/command/set_sub/linetrace.sh
+++ b/command/set_sub/linetrace.sh
@@ -47,7 +47,7 @@ _Dbg_do_set_linetrace() {
 	    _Dbg_write_journal_eval "_Dbg_set_linetrace=0"
 	    ;;
 	d | de | del | dela | delay )
-	    eval "$_seteglob"
+	    eval "$_Dbg_seteglob"
 	    if [[ $2 != $_Dbg_int_pat ]] ; then
 		_Dbg_msg "Bad int parameter: $2"
 		eval "$_Dbg_resteglob"

--- a/command/set_sub/linetrace.sh
+++ b/command/set_sub/linetrace.sh
@@ -50,10 +50,10 @@ _Dbg_do_set_linetrace() {
 	    eval "$_seteglob"
 	    if [[ $2 != $_Dbg_int_pat ]] ; then
 		_Dbg_msg "Bad int parameter: $2"
-		eval "$_resteglob"
+		eval "$_Dbg_resteglob"
 		return 1
 	    fi
-	    eval "$_resteglob"
+	    eval "$_Dbg_resteglob"
 	    _Dbg_write_journal_eval "_Dbg_linetrace_delay=$2"
 	    ;;
 	e | ex | exp | expa | expan | expand )

--- a/command/set_sub/linetrace.sh
+++ b/command/set_sub/linetrace.sh
@@ -48,7 +48,7 @@ _Dbg_do_set_linetrace() {
 	    ;;
 	d | de | del | dela | delay )
 	    eval "$_seteglob"
-	    if [[ $2 != $int_pat ]] ; then
+	    if [[ $2 != $_Dbg_int_pat ]] ; then
 		_Dbg_msg "Bad int parameter: $2"
 		eval "$_resteglob"
 		return 1

--- a/command/set_sub/listsize.sh
+++ b/command/set_sub/listsize.sh
@@ -45,10 +45,10 @@ _Dbg_do_set_listsize() {
     if [[ $1 == $_Dbg_int_pat ]] ; then
 	_Dbg_write_journal_eval "_Dbg_set_listsize=$1"
     else
-	eval "$_resteglob"
+	eval "$_Dbg_resteglob"
 	_Dbg_errmsg "Integer argument expected; got: $1"
 	return 1
     fi
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return 0
 }

--- a/command/set_sub/listsize.sh
+++ b/command/set_sub/listsize.sh
@@ -42,7 +42,7 @@ typeset -xi _Dbg_set_listsize=10
 
 _Dbg_do_set_listsize() {
     eval "$_seteglob"
-    if [[ $1 == $int_pat ]] ; then
+    if [[ $1 == $_Dbg_int_pat ]] ; then
 	_Dbg_write_journal_eval "_Dbg_set_listsize=$1"
     else
 	eval "$_resteglob"

--- a/command/set_sub/listsize.sh
+++ b/command/set_sub/listsize.sh
@@ -41,7 +41,7 @@ See also:
 typeset -xi _Dbg_set_listsize=10
 
 _Dbg_do_set_listsize() {
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     if [[ $1 == $_Dbg_int_pat ]] ; then
 	_Dbg_write_journal_eval "_Dbg_set_listsize=$1"
     else

--- a/command/set_sub/width.sh
+++ b/command/set_sub/width.sh
@@ -35,7 +35,7 @@ Set maximum width of lines to *width*.
 typeset -i _Dbg_set_linewidth; _Dbg_set_linewidth=${COLUMNS:-80}
 
 _Dbg_do_set_width() {
-    if [[ $1 == $int_pat ]] ; then
+    if [[ $1 == $_Dbg_int_pat ]] ; then
 	_Dbg_write_journal_eval "_Dbg_set_linewidth=$1"
     else
 	_Dbg_errmsg "Integer argument expected; got: $1"

--- a/command/show_sub/commands.sh
+++ b/command/show_sub/commands.sh
@@ -41,7 +41,7 @@ _Dbg_do_show_commands() {
 	"+" )
 	    ((hi_start=_Dbg_hi_last_stop-1))
 	    ;;
-	$int_pat | -$int_pat)
+	$_Dbg_int_pat | -$_Dbg_int_pat)
             :
             ;;
 	* )

--- a/command/show_sub/commands.sh
+++ b/command/show_sub/commands.sh
@@ -36,7 +36,7 @@ _Dbg_do_show_commands() {
     if ((default_hi_start < 0)) ; then default_hi_start=0 ; fi
     typeset hi_start=${2:-$default_hi_start}
     
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     case $hi_start in
 	"+" )
 	    ((hi_start=_Dbg_hi_last_stop-1))

--- a/command/show_sub/commands.sh
+++ b/command/show_sub/commands.sh
@@ -47,7 +47,7 @@ _Dbg_do_show_commands() {
 	* )
 	_Dbg_msg "Invalid parameter $hi_start. Need an integer or '+'"
     esac
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     
     typeset -i hi_stop=hi_start-10
     _Dbg_do_history_list $hi_start $hi_stop

--- a/command/signal.sh
+++ b/command/signal.sh
@@ -41,7 +41,7 @@ _Dbg_do_signal() {
   fi
 
   eval "$_seteglob"
-  if [[ $sig == $int_pat ]]; then
+  if [[ $sig == $_Dbg_int_pat ]]; then
     eval "$_resteglob"
     signame=$(_Dbg_signum2name $sig)
     if (( $? != 0 )) ; then

--- a/command/signal.sh
+++ b/command/signal.sh
@@ -42,7 +42,7 @@ _Dbg_do_signal() {
 
   eval "$_seteglob"
   if [[ $sig == $_Dbg_int_pat ]]; then
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     signame=$(_Dbg_signum2name $sig)
     if (( $? != 0 )) ; then
       _Dbg_msg "Bad signal number: $sig"
@@ -50,7 +50,7 @@ _Dbg_do_signal() {
     fi
     signum=sig
   else
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     typeset signum;
     signum=$(_Dbg_name2signum $sig)
     if (( $? != 0 )) ; then

--- a/command/signal.sh
+++ b/command/signal.sh
@@ -40,7 +40,7 @@ _Dbg_do_signal() {
     return 1
   fi
 
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   if [[ $sig == $_Dbg_int_pat ]]; then
     eval "$_Dbg_resteglob"
     signame=$(_Dbg_signum2name $sig)

--- a/init/vars.sh
+++ b/init/vars.sh
@@ -48,7 +48,7 @@ typeset _Dbg_last_printe=''    # expression on last print expression command
 # strings to save and restore the setting of `extglob' in debugger functions
 # that need it
 typeset _seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
-typeset _resteglob='shopt $__eopt extglob'
+typeset _Dbg_resteglob='shopt $__eopt extglob'
 
 typeset _Dbg_int_pat='[0-9]*([0-9])'
 typeset _Dbg_signed_int_pat='?([-+])+([0-9])'

--- a/init/vars.sh
+++ b/init/vars.sh
@@ -47,7 +47,7 @@ typeset _Dbg_last_printe=''    # expression on last print expression command
 
 # strings to save and restore the setting of `extglob' in debugger functions
 # that need it
-typeset _seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
+typeset _Dbg_seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
 typeset _Dbg_resteglob='shopt $__eopt extglob'
 
 typeset _Dbg_int_pat='[0-9]*([0-9])'

--- a/init/vars.sh
+++ b/init/vars.sh
@@ -50,7 +50,7 @@ typeset _Dbg_last_printe=''    # expression on last print expression command
 typeset _seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
 typeset _resteglob='shopt $__eopt extglob'
 
-typeset int_pat='[0-9]*([0-9])'
+typeset _Dbg_int_pat='[0-9]*([0-9])'
 typeset _Dbg_signed_int_pat='?([-+])+([0-9])'
 
 # Set tty to use for output.

--- a/lib/break.sh
+++ b/lib/break.sh
@@ -128,7 +128,7 @@ _Dbg_enable_disable() {
 	  _Dbg_errmsg "Invalid entry number skipped: $i"
       esac
     done
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return 0
   elif [[ $1 == 'action' ]] ; then
     shift
@@ -144,7 +144,7 @@ _Dbg_enable_disable() {
 	  _Dbg_errmsg "Invalid entry number skipped: $i"
       esac
     done
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return 0
   elif [[ $1 == 'breakpoints' ]] ; then
     shift
@@ -173,7 +173,7 @@ _Dbg_enable_disable() {
       _Dbg_errmsg "Invalid entry number skipped: $i"
     esac
   done
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
   return 0
 }
 
@@ -500,5 +500,5 @@ _Dbg_clear_watch() {
     _basdhb_msg "Please specify a numeric watchpoint number"
   fi
 
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
 }

--- a/lib/break.sh
+++ b/lib/break.sh
@@ -118,7 +118,7 @@ _Dbg_enable_disable() {
     shift
     to_go="$*"
     typeset i
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     for i in $to_go ; do
       case $i in
 	$_Dbg_int_pat )
@@ -134,7 +134,7 @@ _Dbg_enable_disable() {
     shift
     to_go="$*"
     typeset i
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     for i in $to_go ; do
       case $i in
 	$_Dbg_int_pat )
@@ -160,7 +160,7 @@ _Dbg_enable_disable() {
   fi
 
   typeset i
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   for i in $to_go ; do
     case $i in
       $_Dbg_watch_pat )
@@ -491,7 +491,7 @@ _Dbg_clear_watch() {
     return 0
   fi
 
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   if [[ $1 == "$_Dbg_int_pat" ]]; then
     _Dbg_write_journal_eval "unset _Dbg_watch_exp[$1]"
     _msg "Watchpoint $i has been cleared"

--- a/lib/break.sh
+++ b/lib/break.sh
@@ -74,7 +74,7 @@ typeset -ai _Dbg_watch_enable=() # 1/0 if enabled or not
 typeset -i  _Dbg_watch_max=0     # Needed because we can't figure out what
                                     # the max index is and arrays can be sparse
 
-typeset     _Dbg_watch_pat="${int_pat}[wW]"
+typeset     _Dbg_watch_pat="${_Dbg_int_pat}[wW]"
 
 #========================= FUNCTIONS   ============================#
 
@@ -121,7 +121,7 @@ _Dbg_enable_disable() {
     eval "$_seteglob"
     for i in $to_go ; do
       case $i in
-	$int_pat )
+	$_Dbg_int_pat )
 	  _Dbg_enable_disable_display $on "$en_dis" $i
 	;;
 	* )
@@ -137,7 +137,7 @@ _Dbg_enable_disable() {
     eval "$_seteglob"
     for i in $to_go ; do
       case $i in
-	$int_pat )
+	$_Dbg_int_pat )
 	  _Dbg_enable_disable_action $on "$en_dis" $i
 	;;
 	* )
@@ -166,7 +166,7 @@ _Dbg_enable_disable() {
       $_Dbg_watch_pat )
         _Dbg_enable_disable_watch $on $en_dis ${del:0:${#del}-1}
         ;;
-      $int_pat )
+      $_Dbg_int_pat )
         _Dbg_enable_disable_brkpt $on "$en_dis" $i
 	;;
       * )
@@ -492,7 +492,7 @@ _Dbg_clear_watch() {
   fi
 
   eval "$_seteglob"
-  if [[ $1 == "$int_pat" ]]; then
+  if [[ $1 == "$_Dbg_int_pat" ]]; then
     _Dbg_write_journal_eval "unset _Dbg_watch_exp[$1]"
     _msg "Watchpoint $i has been cleared"
   else

--- a/lib/display.sh
+++ b/lib/display.sh
@@ -51,7 +51,7 @@ _Dbg_disp_enable_disable() {
     eval "$_seteglob"
     for i in $to_go ; do
 	case $i in
-	    $int_pat )
+	    $_Dbg_int_pat )
                 _Dbg_enable_disable_display $on $en_dis $i
 		;;
 	* )

--- a/lib/display.sh
+++ b/lib/display.sh
@@ -48,7 +48,7 @@ _Dbg_disp_enable_disable() {
 
     typeset to_go="$@"
     typeset i
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     for i in $to_go ; do
 	case $i in
 	    $_Dbg_int_pat )

--- a/lib/display.sh
+++ b/lib/display.sh
@@ -59,7 +59,7 @@ _Dbg_disp_enable_disable() {
 		;;
 	esac
     done
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return 0
 }
 

--- a/lib/fns.sh
+++ b/lib/fns.sh
@@ -218,12 +218,12 @@ function _Dbg_parse_linespec {
   case "$linespec" in
 
     # line number only - use _Dbg_frame_last_filename for filename
-    $int_pat )
+    $_Dbg_int_pat )
       echo "$linespec 0 \"$_Dbg_frame_last_filename\""
       ;;
 
     # file:line
-    [^:][^:]*[:]$int_pat )
+    [^:][^:]*[:]$_Dbg_int_pat )
       # Split the POSIX way
       typeset line_word=${linespec##*:}
       typeset file_word=${linespec%${line_word}}

--- a/lib/fns.sh
+++ b/lib/fns.sh
@@ -214,7 +214,7 @@ function _Dbg_linespec_setup {
 # We return the filename last since that can have embedded blanks.
 function _Dbg_parse_linespec {
   typeset linespec=$1
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   case "$linespec" in
 
     # line number only - use _Dbg_frame_last_filename for filename

--- a/lib/frame.sh
+++ b/lib/frame.sh
@@ -125,10 +125,10 @@ _Dbg_frame_int_setup() {
   eval "$_seteglob"
   if [[ $1 != '' && $1 != $_Dbg_signed_int_pat ]] ; then
       _Dbg_errmsg "Bad integer parameter: $1"
-      eval "$_resteglob"
+      eval "$_Dbg_resteglob"
       return 1
   fi
-  eval "$_resteglob"
+  eval "$_Dbg_resteglob"
   return 0
 }
 

--- a/lib/frame.sh
+++ b/lib/frame.sh
@@ -122,7 +122,7 @@ _Dbg_frame_line() {
 _Dbg_frame_int_setup() {
 
   _Dbg_not_running && return 1
-  eval "$_seteglob"
+  eval "$_Dbg_seteglob"
   if [[ $1 != '' && $1 != $_Dbg_signed_int_pat ]] ; then
       _Dbg_errmsg "Bad integer parameter: $1"
       eval "$_Dbg_resteglob"

--- a/lib/help.sh
+++ b/lib/help.sh
@@ -180,10 +180,10 @@ _Dbg_help_set() {
                 _Dbg_errmsg "Argument required (integer to set it to.)."
             elif [[ $2 != $_Dbg_int_pat ]] ; then
                 _Dbg_errmsg "Integer argument expected; got: $2"
-                eval "$_resteglob"
+                eval "$_Dbg_resteglob"
                 return 1
             fi
-            eval "$_resteglob"
+            eval "$_Dbg_resteglob"
             _Dbg_write_journal_eval "_Dbg_history_length=$2"
             return 0
             ;;

--- a/lib/help.sh
+++ b/lib/help.sh
@@ -178,7 +178,7 @@ _Dbg_help_set() {
             eval "$_seteglob"
             if [[ -z $2 ]] ; then
                 _Dbg_errmsg "Argument required (integer to set it to.)."
-            elif [[ $2 != $int_pat ]] ; then
+            elif [[ $2 != $_Dbg_int_pat ]] ; then
                 _Dbg_errmsg "Integer argument expected; got: $2"
                 eval "$_resteglob"
                 return 1

--- a/lib/help.sh
+++ b/lib/help.sh
@@ -175,7 +175,7 @@ _Dbg_help_set() {
             fi
             ;;
         si | siz | size )
-            eval "$_seteglob"
+            eval "$_Dbg_seteglob"
             if [[ -z $2 ]] ; then
                 _Dbg_errmsg "Argument required (integer to set it to.)."
             elif [[ $2 != $_Dbg_int_pat ]] ; then

--- a/lib/hist.sh
+++ b/lib/hist.sh
@@ -41,8 +41,8 @@ _Dbg_history_parse() {
   [[ -z $history_num ]] && let history_num=$_Dbg_hi-1
 
   if [[ $_Dbg_cmd == h* ]] ; then
-    if [[ $history_num != $int_pat ]] ; then
-      if [[ $history_num == -$int_pat ]] ; then
+    if [[ $history_num != $_Dbg_int_pat ]] ; then
+      if [[ $history_num == -$_Dbg_int_pat ]] ; then
 	history_num=$_Dbg_hi+$history_num
       else
 	_Dbg_errmsg "Invalid history number skipped: $history_num"
@@ -52,7 +52,7 @@ _Dbg_history_parse() {
   else
     # Handle ! form. May need to parse number out number and modifier
     # case $_Dbg_cmd in
-    #   \!\-${int_pat}:p )
+    #   \!\-${_Dbg_int_pat}:p )
     # 	typeset -a word1
     # 	word1=($(_Dbg_split '!' $_Dbg_cmd))
     # 	local -a word2
@@ -61,7 +61,7 @@ _Dbg_history_parse() {
     # 	_Dbg_do_history_list $num $num
     # 	history_num=-1
     # 	;;
-    #   [!]${int_pat}:p )
+    #   [!]${_Dbg_int_pat}:p )
     # 	local -a word1
     # 	word1=($(_Dbg_split '!' $_Dbg_cmd))
     # 	local -a word2
@@ -69,19 +69,19 @@ _Dbg_history_parse() {
     # 	_Dbg_do_history_list ${word2[0]} ${word2[0]}
     # 	history_num=-1
     # 	;;
-    #   \!\-$int_pat )
+    #   \!\-$_Dbg_int_pat )
     # 	local -a word
     # 	word=($(_Dbg_split '!' $_Dbg_cmd))
     # 	history_num=$_Dbg_hi+${word[0]}
     # 	;;
-    #   \!$int_pat )
+    #   \!$_Dbg_int_pat )
     # 	local -a word
     # 	word=($(_Dbg_split '!' $_Dbg_cmd))
     # 	history_num=${word[0]}
     # 	;;
     #   '!' )
-    #     if [[ $history_num != $int_pat ]] ; then
-    # 	  if [[ $history_num == -$int_pat ]] ; then
+    #     if [[ $history_num != $_Dbg_int_pat ]] ; then
+    # 	  if [[ $history_num == -$_Dbg_int_pat ]] ; then
     # 	    history_num=$_Dbg_hi+$history_num
     # 	  else
     # 	    _Dbg_msg "Invalid history number skipped: $history_num"

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -38,7 +38,7 @@ _Dbg_is_int() {
     (( 1 == $# )) || return 1
     typeset rc=1
     eval "$_seteglob"
-    [[ $1 == $int_pat ]] && rc=0
+    [[ $1 == $_Dbg_int_pat ]] && rc=0
     eval "$_resteglob"
     return $rc
 }

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -37,7 +37,7 @@ _Dbg_is_function() {
 _Dbg_is_int() {
     (( 1 == $# )) || return 1
     typeset rc=1
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     [[ $1 == $_Dbg_int_pat ]] && rc=0
     eval "$_Dbg_resteglob"
     return $rc
@@ -47,7 +47,7 @@ _Dbg_is_int() {
 _Dbg_is_signed_int() {
     (( 1 == $# )) || return 1
     typeset rc=1
-    eval "$_seteglob"
+    eval "$_Dbg_seteglob"
     [[ $1 == $_Dbg_signed_int_pat ]] && rc=0
     eval "$_Dbg_resteglob"
     return $rc

--- a/lib/validate.sh
+++ b/lib/validate.sh
@@ -39,7 +39,7 @@ _Dbg_is_int() {
     typeset rc=1
     eval "$_seteglob"
     [[ $1 == $_Dbg_int_pat ]] && rc=0
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return $rc
 }
 
@@ -49,7 +49,7 @@ _Dbg_is_signed_int() {
     typeset rc=1
     eval "$_seteglob"
     [[ $1 == $_Dbg_signed_int_pat ]] && rc=0
-    eval "$_resteglob"
+    eval "$_Dbg_resteglob"
     return $rc
 }
 

--- a/test/unit/test-fns.sh.in
+++ b/test/unit/test-fns.sh.in
@@ -100,7 +100,7 @@ test_fns_onoff()
 test_fns_parse_linespec()
 {
     # Necessary set up for function call.
-    typeset _seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
+    typeset _Dbg_seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
     shopt -s extdebug
     typeset _Dbg_int_pat="[0-9]*([0-9])"
     typeset -i _Dbg_set_debug=1

--- a/test/unit/test-fns.sh.in
+++ b/test/unit/test-fns.sh.in
@@ -102,7 +102,7 @@ test_fns_parse_linespec()
     # Necessary set up for function call.
     typeset _seteglob='local __eopt=-u ; shopt -q extglob && __eopt=-s ; shopt -s extglob'
     shopt -s extdebug
-    typeset int_pat="[0-9]*([0-9])"
+    typeset _Dbg_int_pat="[0-9]*([0-9])"
     typeset -i _Dbg_set_debug=1
 
     function foo { echo 'foo here'; }


### PR DESCRIPTION
Fixes pollution with global variables
- several in `info`, especially `info variables`
- `int_pat`
- `_resteglob`
- `_seteglob`

