### PR TITLE
5.2: Don't allow "info args n" to use n outside the valid range

### DIFF
--- a/command/info_sub/args.sh
+++ b/command/info_sub/args.sh
@@ -44,7 +44,7 @@ See also:
 
 _Dbg_do_info_args() {
 
-    typeset -r frame_start=${1:-0}
+    typeset -r frame_start="${1:-0}"
 
     eval "$_Dbg_seteglob"
     if [[ $frame_start != $_Dbg_int_pat ]] ; then
@@ -53,22 +53,15 @@ _Dbg_do_info_args() {
 	return 1
     fi
 
-    # source /usr/local/share/bashdb/bashdb-trace
-    # _Dbg_debugger
-
-    typeset -i i=$frame_start
-
-    (( i >= _Dbg_stack_size )) && return 1
+    typeset -i i="$frame_start"
+    (( i >= _Dbg_stack_size - 1 )) && return 1
 
     # Figure out which index in BASH_ARGV is position "i" (the place where
     # we start our stack trace from). variable "r" will be that place.
 
     typeset -i adjusted_pos
-    adjusted_pos=$(_Dbg_frame_adjusted_pos $frame_start)
+    adjusted_pos=$(_Dbg_frame_adjusted_pos $i)
     typeset -i arg_count=${BASH_ARGC[$adjusted_pos]}
-    # echo "arg count is " $arg_count
-    # echo "adjusted_pos is" $adjusted_pos
-    # typeset -p BASH_ARGC
 
     # Print out parameter list.
     if (( 0 != ${#BASH_ARGC[@]} )) ; then

--- a/test/data/info-args.cmd
+++ b/test/data/info-args.cmd
@@ -5,4 +5,6 @@ info args
 c hanoi
 info args
 info functions ^ha
+info args 3
+info args 100
 quit

--- a/test/data/info-args.right
+++ b/test/data/info-args.right
@@ -19,5 +19,7 @@ $3 = b
 $4 = c
 +info functions ^ha
 hanoi
-+quit 
++info args 3
++info args 100
++quit
 bashdb: That's all, folks...


### PR DESCRIPTION
The max value of `n` is one less than the current stack depth. `info args 0` prints the arguments of stack item `##1`.
This PR also does a minor cleanup of `args.sh`.

Without this fix, an error would be printed:

```text
bashdb<0> info stack
->0 in file `/home/jansorg/test.sh' at line 1
##1 source("/home/jansorg/test.sh") called from file `./bashdb' at line 107
##2 main("-L", ".", "/home/jansorg/test.sh") called from file `./bashdb' at line 0

bashdb<1> info args 2
./command/info_sub/args.sh: Zeile 78: ((: r = r +  : Syntaxfehler: Operator erwartet. (Fehlerverursachendes Zeichen ist "+  ").
Argument count is 0 for this call.
```

(The error is in German and says "syntax error: expected operator")