### PR TITLE
Resolve filenames in `backtrace` command

### DIFF
--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -2,7 +2,7 @@
 # gdb-like "backtrace" debugger command
 #
 #   Copyright (C) 2002-2006, 2008, 2010-2011, 2018-2019
-#   Rocky Bernstein <rocky@gnu.org>
+#   2024 Rocky Bernstein <rocky@gnu.org>
 #
 #   This program is free software; you can redistribute it and/or
 #   modify it under the terms of the GNU General Public License as
@@ -152,8 +152,6 @@ function _Dbg_do_backtrace {
 	typeset -i arg_count=${BASH_ARGC[$_Dbg_next_argc]}
 	adjusted_pos=$(_Dbg_frame_adjusted_pos $i)
 	_Dbg_msg_nocr $(_Dbg_frame_prefix $i)$i ${FUNCNAME[$adjusted_pos-1]}
-
-	typeset parms=''
 
 	# Print out parameter list.
 	if (( 0 != ${#BASH_ARGC[@]} )) ; then

--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -129,7 +129,7 @@ function _Dbg_do_backtrace {
     if (( frame_start == 0 )) ; then
 	((count--)) ;
 	adjusted_pos=$(_Dbg_frame_adjusted_pos 0)
-	filename=$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")
+	filename="$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")"
 	filename=$(_Dbg_adjust_filename "$filename")
 	_Dbg_frame_print $(_Dbg_frame_prefix 0) '0' '' "$filename" "$_Dbg_frame_last_lineno" ''
     fi

--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -170,7 +170,7 @@ function _Dbg_do_backtrace {
 	    lineno=${BASH_LINENO[$adjusted_pos-1]}
 	fi
 	filename="$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")"
-	filename=$(_Dbg_adjust_filename "$filename")
+	filename="$(_Dbg_adjust_filename "$filename")"
 	_Dbg_msg "($_Dbg_parm_str) called from file \`$filename'" "at line $lineno"
 	if (( show_source )) ; then
 	    _Dbg_get_source_line $lineno "${BASH_SOURCE[$adjusted_pos]}"

--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -130,7 +130,7 @@ function _Dbg_do_backtrace {
 	((count--)) ;
 	adjusted_pos=$(_Dbg_frame_adjusted_pos 0)
 	filename="$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")"
-	filename=$(_Dbg_adjust_filename "$filename")
+	filename="$(_Dbg_adjust_filename "$filename")"
 	_Dbg_frame_print $(_Dbg_frame_prefix 0) '0' '' "$filename" "$_Dbg_frame_last_lineno" ''
     fi
 

--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -129,7 +129,8 @@ function _Dbg_do_backtrace {
     if (( frame_start == 0 )) ; then
 	((count--)) ;
 	adjusted_pos=$(_Dbg_frame_adjusted_pos 0)
-	filename=$(_Dbg_file_canonic "${BASH_SOURCE[$adjusted_pos]}")
+	filename=$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")
+	filename=$(_Dbg_adjust_filename "$filename")
 	_Dbg_frame_print $(_Dbg_frame_prefix 0) '0' '' "$filename" "$_Dbg_frame_last_lineno" ''
     fi
 
@@ -168,7 +169,8 @@ function _Dbg_do_backtrace {
 	else
 	    lineno=${BASH_LINENO[$adjusted_pos-1]}
 	fi
-	filename=$(_Dbg_file_canonic "${BASH_SOURCE[$adjusted_pos]}")
+	filename=$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")
+	filename=$(_Dbg_adjust_filename "$filename")
 	_Dbg_msg "($_Dbg_parm_str) called from file \`$filename'" "at line $lineno"
 	if (( show_source )) ; then
 	    _Dbg_get_source_line $lineno "${BASH_SOURCE[$adjusted_pos]}"

--- a/command/backtrace.sh
+++ b/command/backtrace.sh
@@ -169,7 +169,7 @@ function _Dbg_do_backtrace {
 	else
 	    lineno=${BASH_LINENO[$adjusted_pos-1]}
 	fi
-	filename=$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")
+	filename="$(_Dbg_resolve_expand_filename "${BASH_SOURCE[$adjusted_pos]}")"
 	filename=$(_Dbg_adjust_filename "$filename")
 	_Dbg_msg "($_Dbg_parm_str) called from file \`$filename'" "at line $lineno"
 	if (( show_source )) ; then

--- a/command/load.sh
+++ b/command/load.sh
@@ -2,7 +2,7 @@
 # Debugger load SCRIPT command.
 #
 #   Copyright (C) 2002-2006, 2008, 2010-2011, 2018-2019 Rocky
-#   Bernstein <rocky@gnu.org>
+#   2024 Bernstein <rocky@gnu.org>
 #
 #   This program is free software; you can redistribute it and/or
 #   modify it under the terms of the GNU General Public License as
@@ -54,6 +54,8 @@ _Dbg_do_load() {
 
     _Dbg_readin "$_Dbg_full_filename"
     _Dbg_msg "File $_Dbg_full_filename loaded."
+    _Dbg_file2canonic["${_Dbg_filename}"]="$_Dbg_full_filename"
+
   else
       _Dbg_errmsg "Couldn't resolve or read $_Dbg_filename"
       return 3

--- a/configure.ac
+++ b/configure.ac
@@ -2,7 +2,7 @@
 dnl Process this file with autoconf to produce a configure script.
 
 # Copyright (C) 2002-2012,
-# 2014-2019, 2023 Rocky Bernstein <rocky@gnu.org>
+# 2014-2019, 2023-2024 Rocky Bernstein <rocky@gnu.org>
 
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -231,6 +231,8 @@ AC_CONFIG_FILES([test/unit/test-cmd-info-variables.sh],
                 [chmod +x test/unit/test-cmd-info-variables.sh])
 AC_CONFIG_FILES([test/unit/test-cmd-eval.sh],
                 [chmod +x test/unit/test-cmd-eval.sh])
+AC_CONFIG_FILES([test/unit/test-cmd-load.sh],
+                [chmod +x test/unit/test-cmd-load.sh])
 AC_CONFIG_FILES([test/unit/test-columns.sh],
                 [chmod +x test/unit/test-columns.sh])
 AC_CONFIG_FILES([test/unit/test-file.sh],

--- a/lib/file.sh
+++ b/lib/file.sh
@@ -107,7 +107,7 @@ function _Dbg_resolve_expand_filename {
     for (( i=0 ; i < n; i++ )) ; do
       typeset dirname="${_Dbg_dir[i]}"
       if [[  "$dirname" == '\$cdir' ]] ; then
-	dirname=$_Dbg_cdir
+	dirname="$_Dbg_cdir"
       elif [[ "$dirname" == '\$cwd' ]] ; then
 	dirname=$(pwd)
       fi

--- a/lib/file.sh
+++ b/lib/file.sh
@@ -109,7 +109,7 @@ function _Dbg_resolve_expand_filename {
       if [[  "$dirname" == '\$cdir' ]] ; then
 	dirname="$_Dbg_cdir"
       elif [[ "$dirname" == '\$cwd' ]] ; then
-	dirname=$(pwd)
+	dirname="$(pwd)"
       fi
       if [[ -f "$dirname/$find_file" ]] ; then
 	echo "$dirname/$find_file"

--- a/lib/file.sh
+++ b/lib/file.sh
@@ -105,14 +105,14 @@ function _Dbg_resolve_expand_filename {
     typeset -i n=${#_Dbg_dir[@]}
     typeset -i i
     for (( i=0 ; i < n; i++ )) ; do
-      typeset basename="${_Dbg_dir[i]}"
-      if [[  "$basename" == '\$cdir' ]] ; then
-	basename=$_Dbg_cdir
-      elif [[ "$basename" == '\$cwd' ]] ; then
-	basename=$(pwd)
+      typeset dirname="${_Dbg_dir[i]}"
+      if [[  "$dirname" == '\$cdir' ]] ; then
+	dirname=$_Dbg_cdir
+      elif [[ "$dirname" == '\$cwd' ]] ; then
+	dirname=$(pwd)
       fi
-      if [[ -f "$basename/$find_file" ]] ; then
-	echo "$basename/$find_file"
+      if [[ -f "$dirname/$find_file" ]] ; then
+	echo "$dirname/$find_file"
 	return 0
       fi
     done

--- a/lib/hook.sh
+++ b/lib/hook.sh
@@ -2,7 +2,7 @@
 # hook.sh - Debugger trap hook
 #
 #   Copyright (C) 2002-2011, 2014, 2017-2019
-#   Rocky Bernstein <rocky@gnu.org>
+#   2024 Rocky Bernstein <rocky@gnu.org>
 #
 #   This program is free software; you can redistribute it and/or
 #   modify it under the terms of the GNU General Public License as
@@ -150,6 +150,7 @@ _Dbg_debug_trap_handler() {
     _Dbg_full_filename=$(_Dbg_is_file "$_Dbg_frame_last_filename")
     if [[ -r "$_Dbg_full_filename" ]] ; then
 	_Dbg_file2canonic["$_Dbg_frame_last_filename"]="$_Dbg_full_filename"
+	_Dbg_file2canonic["${BASH_SOURCE[1]}"]="$_Dbg_full_filename"
     fi
 
     # Run applicable action statement

--- a/test/unit/.gitignore
+++ b/test/unit/.gitignore
@@ -1,6 +1,6 @@
-/*~
-/*.trs
 /*.log
+/*.trs
+/*~
 /Makefile
 /Makefile.in
 /require_me.sh
@@ -11,6 +11,7 @@
 /test-cmd-complete.sh
 /test-cmd-eval.sh
 /test-cmd-info-variables.sh
+/test-cmd-load.sh
 /test-columns.sh
 /test-eval.sh
 /test-file.sh

--- a/test/unit/Makefile.am
+++ b/test/unit/Makefile.am
@@ -8,6 +8,7 @@ TESTS = test-action.sh \
         test-cmd-complete.sh \
         test-cmd-eval.sh \
         test-cmd-info-variables.sh \
+        test-cmd-load.sh \
         test-columns.sh \
         test-filecache.sh \
         test-file.sh \

--- a/test/unit/test-cmd-load.sh.in
+++ b/test/unit/test-cmd-load.sh.in
@@ -1,0 +1,37 @@
+#!@SH_PROG@
+# -*- shell-script -*-
+
+typeset -a messages=()
+
+test_cmd_load()
+{
+    # Check that load_file caches mapping from short name
+    # to fully-resolved file name
+    local find_file="./test-cmd-load.sh.in"
+    cd $(dirname ${BASH_SOURCE[0]})
+    _Dbg_init_cwd=$(pwd)
+    _Dbg_do_load "$find_file"
+    assertEquals ${#messages[@]} 0
+    typeset cached_file="${_Dbg_file2canonic[$find_file]}"
+    assertEquals "$cached_file" $(_Dbg_resolve_expand_filename "$find_file")
+}
+
+abs_top_srcdir=@abs_top_srcdir@
+# Make sure $abs_top_srcdir has a trailing slash
+abs_top_srcdir=${abs_top_srcdir%%/}/
+. ${abs_top_srcdir}test/unit/helper.sh
+. ${abs_top_srcdir}init/pre.sh
+for file in alias help fns ; do
+    . ${abs_top_srcdir}lib/${file}.sh
+done
+. ${abs_top_srcdir}lib/filecache.sh
+. ${abs_top_srcdir}lib/file.sh
+. ${abs_top_srcdir}lib/unescape.sh
+. ${abs_top_srcdir}command/load.sh
+set -- # reset $# so shunit2 doesn't get confused.
+[[ @CMDLINE_INVOKED@ ]] && . ${shunit_file}
+
+# Replace lib/msg _Dbg_msg with sothing to track.
+function _Dbg_msg {
+    messages+=("$@)
+}


### PR DESCRIPTION
Save relative to absolute file name mapping when doing "load" command, and in the debugger callback hook .

Resolve file paths in "backtrace" command.