### PR TITLE
4.4: Improve CI and setup with Bash docker image

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,7 @@
 name: "bashdb CI"
 on:
   push:
+  workflow_dispatch:
 
 jobs:
   linux:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,7 +6,7 @@ jobs:
   linux:
     name: "Linux"
     runs-on: ubuntu-latest
-    container: bash:4.4
+    container: bash:4.4-alpine3.20
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/check-prefix.sh
+++ b/check-prefix.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if [[ $# != 2 ]]; then
     echo  >&2 "Usage $0 BASH_PROGRAM PREFIX"
     exit 3


### PR DESCRIPTION
- This brings back stable CI by working around https://github.com/tianon/docker-bash/issues/44
- It also uses `env bash` for `check-prefix.sh` to make it work better in Bash docker images.
- Enables manual execution of the GitHub Actions workflow

Same as https://github.com/Trepan-Debuggers/bashdb/pull/59, but for bash-4.4