### PR TITLE
Fix breakpoint hit in file sourced with relative path after script changed the working directory

### DIFF
--- a/lib/file.sh
+++ b/lib/file.sh
@@ -24,8 +24,8 @@ typeset -a _Dbg_dir
 _Dbg_dir=('\$cdir' '\$cwd' )
 
 # _Dbg_cdir is the directory in which the script is located.
-[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir=${_Dbg_source_file%/*}
-[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir=$(pwd)
+[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir="${_Dbg_source_file%/*}"
+[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir="$(pwd)"
 
 # Either fill out or strip filename as determined by "basename_only"
 # and annotate settings

--- a/lib/filecache.sh
+++ b/lib/filecache.sh
@@ -139,14 +139,14 @@ function _Dbg_is_file {
 
   if [[ ${find_file:0:1} == '/' ]] ; then
       # Absolute file name
-      try_find_file=$(_Dbg_expand_filename "$find_file")
+      try_find_file="$(_Dbg_expand_filename "$find_file")"
       if [[ -n ${_Dbg_filenames[$try_find_file]} ]] ; then
 	  echo "$try_find_file"
 	  return 0
       fi
   elif [[ ${find_file:0:1} == '.' ]] ; then
       # Relative file name
-      try_find_file=$(_Dbg_expand_filename "${_Dbg_init_cwd}/$find_file")
+      try_find_file="$(_Dbg_expand_filename "${_Dbg_init_cwd}/$find_file")"
       # FIXME: turn into common subroutine
       if [[ -n ${_Dbg_filenames[$try_find_file]} ]] ; then
 	  echo "$try_find_file"
@@ -164,7 +164,7 @@ basename=$_Dbg_cdir
     elif [[ $basename == '\$cwd' ]] ; then
 basename=$(pwd)
     fi
-    try_find_file=$(_Dbg_expand_filename "$basename/$find_file")
+    try_find_file="$(_Dbg_expand_filename "$basename/$find_file")"
     if [[ -n ${_Dbg_filenames[$try_find_file]} ]] ; then
   echo "$try_find_file"
   return 0

--- a/lib/filecache.sh
+++ b/lib/filecache.sh
@@ -152,24 +152,25 @@ function _Dbg_is_file {
 	  echo "$try_find_file"
 	  return 0
       fi
-  else
-    # Resolve file using _Dbg_dir
-    typeset -i n=${#_Dbg_dir[@]}
-    typeset -i i
-    for (( i=0 ; i < n; i++ )) ; do
-      typeset basename="${_Dbg_dir[i]}"
-      if [[  $basename == '\$cdir' ]] ; then
-	basename=$_Dbg_cdir
-      elif [[ $basename == '\$cwd' ]] ; then
-	basename=$(pwd)
-      fi
-      try_find_file="$basename/$find_file"
-      if [[ -f "$try_find_file" ]] ; then
-	  echo "$try_find_file"
-	  return 0
-      fi
-    done
   fi
+
+  # Resolve file using _Dbg_dir
+  typeset -i n=${#_Dbg_dir[@]}
+  typeset -i i
+  for (( i=0 ; i < n; i++ )) ; do
+    typeset basename="${_Dbg_dir[i]}"
+    if [[  $basename == '\$cdir' ]] ; then
+basename=$_Dbg_cdir
+    elif [[ $basename == '\$cwd' ]] ; then
+basename=$(pwd)
+    fi
+    try_find_file=$(_Dbg_expand_filename "$basename/$find_file")
+    if [[ -n ${_Dbg_filenames[$try_find_file]} ]] ; then
+  echo "$try_find_file"
+  return 0
+    fi
+  done
+
   echo ''
   return 1
 }


### PR DESCRIPTION
The script (shown below) of my integration tests of BashSupport Pro failed to hit a breakpoint in the function definition of `include3.sh`.
The breakpoint was not hit because the lookup in `hook.sh` was not using the current working directory of the script to find a path by relative path. In this case `../dir3/include3.sh` was not looked inside the PWD `$DIR/dir2` but only elsewhere.

This PR changes the file lookup to always use the configured lookup directories `_Dbg_dir` as fallback if the lookup of absolute and relative paths did not yield a valid result.
Also, the result of the lookup based on `_Dbg_dir` was not checked against `$_Dbg_filenames` like the lookup a few lines above.

Tests are passing and the breakpoint is now hit. But I'm not sure how to add a test case for this.

**Question:** 
This code looks suspiciously similar to the code I changed. Should I change this, even though I'm not sure how it's used?

https://github.com/Trepan-Debuggers/bashdb/blob/b78910ad9efa514685dfd9e9c829949387422ec9/lib/file.sh#L104-L118 


### Script of my test case
```bash
#!/bin/bash

DIR="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)"

cd "$DIR/dir2"

. ../dir3/include3.sh
include3 # function defined in include3.sh
```