### PR TITLE
Fix resolving of relative script paths

### DIFF
--- a/lib/file.sh
+++ b/lib/file.sh
@@ -18,14 +18,15 @@
 #   with bashdb; see the file COPYING.  If not, write to the Free Software
 #   Foundation, 59 Temple Place, Suite 330, Boston, MA 02111 USA.
 
-# Directory search patch for unqualified file names
-
+# Directory search patch for unqualified file names.
+# We resolve against the current working directory first because that's most likely what the script does at runtime.
+# cwd is the current working directory, _Dbg_cdir is the directory in which the script is located.
 typeset -a _Dbg_dir
-_Dbg_dir=('\$cdir' '\$cwd' )
+_Dbg_dir=( '\$cwd' '\$cdir' )
 
 # _Dbg_cdir is the directory in which the script is located.
-[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir=${_Dbg_source_file%/*}
-[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir=$(pwd)
+[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir="${_Dbg_source_file%/*}"
+[[ -z ${_Dbg_cdir} ]] && typeset _Dbg_cdir="$(pwd)"
 
 # Either fill out or strip filename as determined by "basename_only"
 # and annotate settings
@@ -66,57 +67,56 @@ _Dbg_tilde_expand_filename() {
 # Resolve $1 to a full file name which exists. First see if filename has been
 # mentioned in a debugger "file" command. If not and the file name
 # is a relative name use _Dbg_dir to substitute a relative directory name.
+# '' is echo'd if no file found. Return 0 (in $?) if found, 1 if not.
 #
 function _Dbg_resolve_expand_filename {
-
   if (( $# == 0 )) ; then
-    _Dbg_errmsg \
-	"Internal debug error _Dbg_resolve_expand_filename(): null file to find"
+    _Dbg_errmsg "Internal debug error _Dbg_resolve_expand_filename(): null file to find"
     echo ''
     return 1
   fi
+
   typeset find_file="$1"
-
-  # Is this one of the files we've that has been specified in a debugger
-  # "FILE" command?
-  typeset found_file
-  found_file="${_Dbg_file2canonic[$find_file]}"
-  if [[ -n  $found_file ]] ; then
-    echo "$found_file"
+  # Is this one of the files we've that has been specified in a debugger # "FILE" command?
+  typeset try_find_file
+  try_find_file="${_Dbg_file2canonic["$find_file"]}"
+  if [[ -n "$try_find_file" ]] ; then
+    echo "$try_find_file"
     return 0
   fi
 
+  # Absolute path name
   if [[ ${find_file:0:1} == '/' ]] ; then
-    # Absolute file name
-    full_find_file=$(_Dbg_expand_filename "$find_file")
-    echo "$full_find_file"
-    return 0
-  elif [[ ${find_file:0:1} == '.' ]] ; then
-    # Relative file name
-    full_find_file=$(_Dbg_expand_filename "${_Dbg_init_cwd}/$find_file")
-    if [[ -z "$full_find_file" ]] || [[ ! -r $full_find_file ]]; then
-      # Try using cwd rather than Dbg_init_cwd
-      full_find_file=$(_Dbg_expand_filename "$find_file")
+    try_find_file="$(_Dbg_expand_filename "$find_file")"
+    if [[ -e "$try_find_file" ]] ; then
+      echo "$try_find_file"
+      return 0
     fi
-    echo "$full_find_file"
-    return 0
-  else
-    # Resolve file using _Dbg_dir
-    typeset -i n=${#_Dbg_dir[@]}
-    typeset -i i
-    for (( i=0 ; i < n; i++ )) ; do
-      typeset dirname="${_Dbg_dir[i]}"
-      if [[  "$dirname" == '\$cdir' ]] ; then
-	dirname="$_Dbg_cdir"
-      elif [[ "$dirname" == '\$cwd' ]] ; then
-	dirname="$(pwd)"
-      fi
-      if [[ -f "$dirname/$find_file" ]] ; then
-	echo "$dirname/$find_file"
-	return 0
-      fi
-    done
+
+    # Return error because absolute path does not exist
+    echo ''
+    return 1
   fi
+
+  # Resolve file using _Dbg_dir
+  typeset -i n=${#_Dbg_dir[@]}
+  typeset -i i
+  for (( i=0 ; i < n; i++ )) ; do
+    typeset basedir="${_Dbg_dir[i]}"
+    if [[ "$basedir" == '\$cdir' ]] ; then
+      basedir="$_Dbg_cdir"
+    elif [[ "$basedir" == '\$cwd' ]] ; then
+      basedir="$(pwd -P)"
+    fi
+
+    try_find_file="$(_Dbg_expand_filename "$basedir/$find_file")"
+    if [[ -e "$try_find_file" ]] ; then
+      echo "$try_find_file"
+      return 0
+    fi
+  done
+
+  # Return error because no file was found
   echo ''
   return 1
 }

--- a/lib/filecache.sh
+++ b/lib/filecache.sh
@@ -126,50 +126,14 @@ function _Dbg_is_file {
     echo ''
     return 1
   fi
-  # first character might be encoded as \057 == '/',
-  # find_file:0:1 == "\" , true story
-  typeset find_file="$(printf "$1")"
+
   typeset try_find_file
-
-  if [[ -z $find_file ]] ; then
-    _Dbg_errmsg "Internal debug error _Dbg_is_file(): file argument null"
-    echo ''
-    return 1
+  try_find_file="$(_Dbg_resolve_expand_filename "$1")"
+  if [[ -n "${_Dbg_filenames["$try_find_file"]}" ]] ; then
+	  echo "$try_find_file"
+	  return 0
   fi
 
-  if [[ ${find_file:0:1} == '/' ]] ; then
-      # Absolute file name
-      try_find_file=$(_Dbg_expand_filename "$find_file")
-      if [[ -n ${_Dbg_filenames[$try_find_file]} ]] ; then
-	  echo "$try_find_file"
-	  return 0
-      fi
-  elif [[ ${find_file:0:1} == '.' ]] ; then
-      # Relative file name
-      try_find_file=$(_Dbg_expand_filename "${_Dbg_init_cwd}/$find_file")
-      # FIXME: turn into common subroutine
-      if [[ -n ${_Dbg_filenames[$try_find_file]} ]] ; then
-	  echo "$try_find_file"
-	  return 0
-      fi
-  else
-    # Resolve file using _Dbg_dir
-    typeset -i n=${#_Dbg_dir[@]}
-    typeset -i i
-    for (( i=0 ; i < n; i++ )) ; do
-      typeset basename="${_Dbg_dir[i]}"
-      if [[  $basename == '\$cdir' ]] ; then
-	basename=$_Dbg_cdir
-      elif [[ $basename == '\$cwd' ]] ; then
-	basename=$(pwd)
-      fi
-      try_find_file="$basename/$find_file"
-      if [[ -f "$try_find_file" ]] ; then
-	  echo "$try_find_file"
-	  return 0
-      fi
-    done
-  fi
   echo ''
   return 1
 }

--- a/lib/filecache.sh
+++ b/lib/filecache.sh
@@ -129,7 +129,7 @@ function _Dbg_is_file {
 
   typeset try_find_file
   try_find_file="$(_Dbg_resolve_expand_filename "$1")"
-  if [[ -n "${_Dbg_filenames["$try_find_file"]}" ]] ; then
+  if [[ -n "$try_find_file" && -n "${_Dbg_filenames["$try_find_file"]}" ]] ; then
 	  echo "$try_find_file"
 	  return 0
   fi

--- a/test/unit/test-file.sh.in
+++ b/test/unit/test-file.sh.in
@@ -1,5 +1,6 @@
 #!@SH_PROG@
 # -*- shell-script -*-
+this_script=test-filecache.sh
 
 # Test _Dbg_file_canonic
 test_file_file_canonic()
@@ -88,10 +89,9 @@ test_file_resolve_expand_filename()
     filename=$(_Dbg_resolve_expand_filename .)
     assertEquals '0' $?
     assertEquals '/' "${filename:0:1}"
-    filename=$(_Dbg_resolve_expand_filename ./fdafdsa)
+    filename=$(_Dbg_resolve_expand_filename ./$this_script)
     assertEquals '0' $?
     typeset -i size=${#filename}
-    # assertEquals 'fdafdsas' "${filename:$size-8}"
     assertNotEquals '.' "${filename:$size-1}"
 }
 


### PR DESCRIPTION
At first, the script's working directory is used to resolve a relative path. Then, the script's parent directory is used. This commit removes duplicated code shared between file.sh and filecache.sh.

- I've switched the lookup order, `_Dbg_dir=('\$cdir' '\$cwd' )` to `_Dbg_dir=('\$cwd' '\$cdir' )`, because IMHO the current working directory should be looked at first. At runtime, that's what the debuggee does (I suppose)
- I've changed `typeset _Dbg_cdir="${_Dbg_source_file%/*}"` to `typeset _Dbg_cdir="${_Dbg_init_cwd%/*}"` because that seems more suitable to reference the script's location. In `dbg-main.sh` variable `_Dbg_source_file` is used in a loop (without a break) and does not seem to refer to the debuggee script passed to `bashdb`. Because of the missing break, I think it's always set to `$DBG_RESTART_FILE` when the loop is done.

Supersedes #61 

Update: This is breaking other cases, discussed in https://github.com/Trepan-Debuggers/bashdb/issues/63