### PR TITLE
port to oracle linux 9

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -29,7 +29,7 @@ AC_INIT([bashdb],[OK_BASH_VERS-relstatus],[https://sourceforge.net/p/bashdb/bugs
 dnl make sure we are using a recent autoconf version.
 dnl In particular we assume prefix will be set to "NONE" if --prefix
 dnl isn't given. Earlier autoconf' used "no" instead of "NONE".
-AC_PREREQ([2.71])
+AC_PREREQ([2.69])
 
 ##################################################################
 # See if --prefix was set. If not, set it to a reasonable default

--- a/doc/bashdb.texi
+++ b/doc/bashdb.texi
@@ -723,6 +723,7 @@ command string (@code{-c}).
 * Debugging a bash string from the command line::
 * Having bash invoke the debugger and your shell script::
 * Having the debugger invoke your shell script::
+* Calling the debugger from inside a running bash script::
 @end menu
 
 @node Debugging a bash string from the command line

--- a/lib/term-highlight.py
+++ b/lib/term-highlight.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #   Copyright (C) 2016, 2019, 2023 Rocky Bernstein <rocky@gnu.org>
 #

--- a/rpm/bashdb-5.2-0.spec
+++ b/rpm/bashdb-5.2-0.spec
@@ -1,0 +1,104 @@
+%bcond_with tests
+%define rversion 5.2-1.1.2
+
+Name:           bashdb
+Summary:        BASH debugger, the BASH symbolic debugger
+Version:        5.2
+Release:        2%{?dist}
+License:        GPLv2+
+Group:          Development/Debuggers
+Url:            https://github.com/Trepan-Debuggers/bashdb
+Source0:        %{name}-%{rversion}.tar.gz
+Buildroot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRequires:  bash >= 5.1
+BuildRequires:  python-pygments
+Requires(post): /sbin/install-info
+Requires(preun): /sbin/install-info
+Requires:       bash >= 5.1
+BuildArch:      noarch
+
+%description
+The Bash Debugger Project is a source-code debugger for bash,
+which follows the gdb command syntax.
+The purpose of the BASH debugger is to check
+what is going on “inside” a bash script, while it executes:
+    * Start a script, specifying conditions that might affect its behavior.
+    * Stop a script at certain conditions (break points).
+    * Examine the state of a script.
+    * Experiment, by changing variable values on the fly.
+The 4.0 series is a complete rewrite of the previous series.
+Bashdb can be used with ddd: ddd --debugger %{_bindir}/%{name} <script-name>.
+
+%prep
+%setup -q -n %{name}-%{rversion}
+
+%build
+%configure
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+
+%if %{with tests}
+%check
+make check
+%endif
+
+%post
+mkdir -p /usr/share/info || :
+/sbin/install-info /usr/share/info/bashdb.info /usr/share/info/dir || :
+
+%postun
+if [ "$1" = 0 ]; then
+   /sbin/install-info --delete %{_infodir}/%{name}.info %{_infodir}/dir || :
+fi
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%doc doc/*.html ChangeLog AUTHORS COPYING INSTALL TODO README.md NEWS.md THANKS.md
+/usr/bin/bashdb
+/usr/share/bashdb
+/usr/share/info/bashdb.info.gz
+/usr/share/info/dir
+/usr/share/man/man1/bashdb.1.gz
+
+%changelog
+* Sat Nov 9 2013 Rocky Bernstein <rlbernst@yu.edu> 4.2_0.9-1
+- Make it work on RHEL5 for bash4
+
+* Tue Sep 27 2011 Rocky Bernstein <rlbernst@yu.edu> 4.2_0.9-1
+- Updated to 4.2-0.9
+
+* Tue Mar 29 2011 Paulo Roma <roma@lcg.ufrj.br> 4.2_0.8-1
+- Updated to 4.2-0.7
+
+* Sun Mar 06 2011 Paulo Roma <roma@lcg.ufrj.br> 4.2_0.6-1
+- Updated to 4.2-0.6
+- Emacs lisp code has been removed upstream.
+
+* Mon Feb 07 2011 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 4.1_0.4-2
+- Rebuilt for https://fedoraproject.org/wiki/Fedora_15_Mass_Rebuild
+
+* Thu Jul 22 2010 Paulo Roma <roma@lcg.ufrj.br> 4.1_0.4-1
+- Updated to 4.1-0.4
+
+* Sun Mar 14 2010 Jonathan G. Underwood <jonathan.underwood@gmail.com> - 4.0_0.4-3
+- Update package to comply with emacs add-on packaging guidelines
+- Split out separate Elisp source file package
+
+* Sun Dec 27 2009 Paulo Roma <roma@lcg.ufrj.br> 4.0_0.4-2
+- Updated to 4.0-0.4
+
+* Fri Apr 10 2009 Paulo Roma <roma@lcg.ufrj.br> 4.0_0.3-2
+- Updated to 4.0-0.3 for supporting bash 4.0
+- Added building option "with tests".
+
+* Wed Feb 25 2009 Paulo Roma <roma@lcg.ufrj.br> 4.0_0.2-1
+- Completely rewritten for Fedora.
+
+* Tue Nov 18 2008 Manfred Tremmel <Manfred.Tremmel@iiv.de>
+- update to 4.0-0.2


### PR DESCRIPTION
This merge request is to build an RPM on Oracle Linux 9 (OL9).
1. Bump down the required version of autoconf.  Seems to work fine with 2.69, the version on OL9.
2. A missing node in the documentation was causing a build failure (there are still a few warnings that are not addressed in this MR)
3. RPM post build steps prevent version-less python shebang. again, this seemed to have no effect on unit tests.
4. most importantly, I created an RPM spec file for this version.

The steps I took to build the RPM:
```bash
autoreconf -vi
./configure --prefix=/usr --enable-maintainer-mode
make
make check
make dist
mkdir -p ~/rpmbuild/{BUILD,RPMS,SOURCES,SPECS,SRPMS} 
mv bashdb-5.2-1.1.2.tar.gz ~/rpmbuild/SOURCES/
rpmbuild -ba rpm/bashdb-5.2-0.spec
```

Then to install:
```bash
sudo dnf install -y ~/rpmbuild/RPMS/noarch/bashdb-5.2-2.el9.noarch.rpm
```

